### PR TITLE
Add transaction categories

### DIFF
--- a/db/migrations/20260508000000_transaction_categories.sql
+++ b/db/migrations/20260508000000_transaction_categories.sql
@@ -1,0 +1,39 @@
+-- migrate:up
+SET search_path TO transactions, public;
+CREATE TABLE category (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    code VARCHAR UNIQUE NOT NULL,
+    name VARCHAR NOT NULL,
+    description TEXT,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_category_code ON category(code);
+CREATE INDEX idx_category_is_active ON category(is_active);
+ALTER TABLE transaction ADD COLUMN category_id BIGINT REFERENCES category(id);
+CREATE INDEX idx_transaction_category_id ON transaction(category_id);
+DROP INDEX IF EXISTS idx_transaction_budget_category_id;
+-- Intentional destructive replacement: budget_category mixed category assignment
+-- with budget allocation, and no mapping is preserved to the new global category table.
+ALTER TABLE transaction DROP COLUMN budget_category_id;
+DROP TABLE budget_category;
+
+-- migrate:down
+SET search_path TO transactions, public;
+CREATE TABLE budget_category (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    budget_id BIGINT,
+    category_name VARCHAR NOT NULL,
+    allocation REAL NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (budget_id) REFERENCES budget(id)
+);
+ALTER TABLE transaction ADD COLUMN budget_category_id BIGINT REFERENCES budget_category(id);
+CREATE INDEX idx_transaction_budget_category_id ON transaction(budget_category_id);
+DROP INDEX IF EXISTS idx_transaction_category_id;
+ALTER TABLE transaction DROP COLUMN category_id;
+DROP INDEX IF EXISTS idx_category_is_active;
+DROP INDEX IF EXISTS idx_category_code;
+DROP TABLE category;

--- a/internal/app/categories.go
+++ b/internal/app/categories.go
@@ -1,0 +1,192 @@
+package app
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"regexp"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"rdmm404/voltr-finance/internal/database"
+	"rdmm404/voltr-finance/internal/database/sqlc"
+)
+
+var categoryCodePattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+
+type CategoryDTO struct {
+	ID          int64   `json:"id"`
+	Code        string  `json:"code"`
+	Name        string  `json:"name"`
+	Description *string `json:"description,omitempty"`
+	IsActive    bool    `json:"isActive"`
+}
+
+type CategoryRefDTO struct {
+	ID   int64  `json:"id"`
+	Code string `json:"code"`
+	Name string `json:"name"`
+}
+
+type CreateCategoryRequest struct {
+	Name        string  `json:"name"`
+	Code        *string `json:"code,omitempty"`
+	Description *string `json:"description,omitempty"`
+}
+
+type ListCategoriesRequest struct {
+	IncludeInactive bool `json:"includeInactive,omitempty"`
+}
+
+type UpdateCategoryRequest struct {
+	ID               int64   `json:"id"`
+	Name             *string `json:"name,omitempty"`
+	Description      *string `json:"description,omitempty"`
+	ClearDescription bool    `json:"clearDescription,omitempty"`
+}
+
+func (s *Service) CreateCategory(ctx context.Context, req CreateCategoryRequest) (CategoryDTO, error) {
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		return CategoryDTO{}, NewError(CodeValidationError, "category name is required", nil)
+	}
+
+	code := categoryCodeFromName(name)
+	if req.Code != nil {
+		code = strings.TrimSpace(*req.Code)
+	}
+	if !categoryCodePattern.MatchString(code) {
+		return CategoryDTO{}, NewError(CodeValidationError, "category code must be a lowercase slug", nil)
+	}
+
+	category, err := s.repo.CreateCategory(ctx, sqlc.CreateCategoryParams{
+		Code:        code,
+		Name:        name,
+		Description: req.Description,
+	})
+	if err != nil {
+		return CategoryDTO{}, mapCategoryError(err)
+	}
+	return categoryDTO(category), nil
+}
+
+func (s *Service) ListCategories(ctx context.Context, req ListCategoriesRequest) ([]CategoryDTO, error) {
+	rows, err := s.repo.ListCategories(ctx, req.IncludeInactive)
+	if err != nil {
+		return nil, mapCategoryError(err)
+	}
+
+	categories := make([]CategoryDTO, 0, len(rows))
+	for _, row := range rows {
+		categories = append(categories, categoryDTO(row))
+	}
+	return categories, nil
+}
+
+func (s *Service) GetCategoryByCode(ctx context.Context, code string) (CategoryDTO, error) {
+	code = strings.TrimSpace(code)
+	if !categoryCodePattern.MatchString(code) {
+		return CategoryDTO{}, NewError(CodeValidationError, "category code must be a lowercase slug", nil)
+	}
+
+	category, err := s.repo.GetCategoryByCode(ctx, code)
+	if err != nil {
+		return CategoryDTO{}, mapCategoryError(err)
+	}
+	return categoryDTO(category), nil
+}
+
+func (s *Service) UpdateCategory(ctx context.Context, req UpdateCategoryRequest) (CategoryDTO, error) {
+	if req.ID == 0 {
+		return CategoryDTO{}, NewError(CodeValidationError, "category id is required", nil)
+	}
+	if req.Name == nil && req.Description == nil && !req.ClearDescription {
+		return CategoryDTO{}, NewError(CodeValidationError, "at least one category field is required", nil)
+	}
+
+	name := ""
+	setName := false
+	if req.Name != nil {
+		name = strings.TrimSpace(*req.Name)
+		if name == "" {
+			return CategoryDTO{}, NewError(CodeValidationError, "category name is required", nil)
+		}
+		setName = true
+	}
+
+	description := req.Description
+	if req.ClearDescription {
+		description = nil
+	}
+
+	category, err := s.repo.UpdateCategory(ctx, sqlc.UpdateCategoryParams{
+		ID:             req.ID,
+		SetName:        setName,
+		Name:           name,
+		SetDescription: req.Description != nil || req.ClearDescription,
+		Description:    description,
+	})
+	if err != nil {
+		return CategoryDTO{}, mapCategoryError(err)
+	}
+	return categoryDTO(category), nil
+}
+
+func (s *Service) DeactivateCategory(ctx context.Context, code string) (CategoryDTO, error) {
+	code = strings.TrimSpace(code)
+	if !categoryCodePattern.MatchString(code) {
+		return CategoryDTO{}, NewError(CodeValidationError, "category code must be a lowercase slug", nil)
+	}
+
+	category, err := s.repo.DeactivateCategory(ctx, code)
+	if err != nil {
+		return CategoryDTO{}, mapCategoryError(err)
+	}
+	return categoryDTO(category), nil
+}
+
+func categoryCodeFromName(name string) string {
+	var b strings.Builder
+	lastHyphen := true
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastHyphen = false
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r + ('a' - 'A'))
+			lastHyphen = false
+		default:
+			if !lastHyphen {
+				b.WriteByte('-')
+				lastHyphen = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func categoryDTO(category sqlc.Category) CategoryDTO {
+	return CategoryDTO{
+		ID:          category.ID,
+		Code:        category.Code,
+		Name:        category.Name,
+		Description: category.Description,
+		IsActive:    category.IsActive,
+	}
+}
+
+func mapCategoryError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return NewError(CodeValidationError, "category not found", err)
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && database.PgErrorCode(pgErr.Code) == database.ErrorCodeUniqueViolation {
+		return NewError(CodeValidationError, "category code already exists", err)
+	}
+	return NewError(CodeDatabaseError, "database error", err)
+}

--- a/internal/app/categories_test.go
+++ b/internal/app/categories_test.go
@@ -1,0 +1,115 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"rdmm404/voltr-finance/internal/database/sqlc"
+)
+
+func TestCreateCategoryGeneratesCode(t *testing.T) {
+	repo := &fakeRepo{}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	category, err := svc.CreateCategory(context.Background(), CreateCategoryRequest{
+		Name: "Restaurants & Takeout",
+	})
+
+	if err != nil {
+		t.Fatalf("CreateCategory returned error: %v", err)
+	}
+	if category.Code != "restaurants-takeout" {
+		t.Fatalf("Code = %q, want restaurants-takeout", category.Code)
+	}
+	if repo.lastCreateCategory.Code != "restaurants-takeout" || repo.lastCreateCategory.Name != "Restaurants & Takeout" {
+		t.Fatalf("CreateCategoryParams = %+v, want generated code and name", repo.lastCreateCategory)
+	}
+}
+
+func TestCreateCategoryGeneratesASCIICodeFromUnicodeName(t *testing.T) {
+	repo := &fakeRepo{}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	category, err := svc.CreateCategory(context.Background(), CreateCategoryRequest{
+		Name: "Café au lait",
+	})
+
+	if err != nil {
+		t.Fatalf("CreateCategory returned error: %v", err)
+	}
+	if category.Code != "caf-au-lait" {
+		t.Fatalf("Code = %q, want caf-au-lait", category.Code)
+	}
+	if repo.lastCreateCategory.Code != "caf-au-lait" {
+		t.Fatalf("CreateCategoryParams.Code = %q, want caf-au-lait", repo.lastCreateCategory.Code)
+	}
+}
+
+func TestCreateCategoryAcceptsExplicitCode(t *testing.T) {
+	repo := &fakeRepo{}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	category, err := svc.CreateCategory(context.Background(), CreateCategoryRequest{
+		Name: "Restaurants & Takeout",
+		Code: strPtr("restaurants"),
+	})
+
+	if err != nil {
+		t.Fatalf("CreateCategory returned error: %v", err)
+	}
+	if category.Code != "restaurants" {
+		t.Fatalf("Code = %q, want restaurants", category.Code)
+	}
+}
+
+func TestCreateCategoryRejectsInvalidCode(t *testing.T) {
+	svc := NewService(&fakeRepo{}, &fakeTransactionService{})
+
+	_, err := svc.CreateCategory(context.Background(), CreateCategoryRequest{
+		Name: "Groceries",
+		Code: strPtr("Groceries!"),
+	})
+
+	if appErr, ok := err.(*AppError); !ok || appErr.Code != CodeValidationError {
+		t.Fatalf("err = %v, want validation error", err)
+	}
+}
+
+func TestListCategoriesMapsRows(t *testing.T) {
+	repo := &fakeRepo{listCategoriesResult: []sqlc.Category{
+		{ID: 1, Code: "groceries", Name: "Groceries", IsActive: true},
+		{ID: 2, Code: "utilities", Name: "Utilities", IsActive: true},
+	}}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	categories, err := svc.ListCategories(context.Background(), ListCategoriesRequest{
+		IncludeInactive: true,
+	})
+
+	if err != nil {
+		t.Fatalf("ListCategories returned error: %v", err)
+	}
+	if len(categories) != 2 || categories[0].Code != "groceries" || categories[1].Code != "utilities" {
+		t.Fatalf("categories = %+v, want mapped category DTOs", categories)
+	}
+	if !repo.lastListCategoriesIncludeInactive {
+		t.Fatalf("ListCategories includeInactive = false, want true")
+	}
+}
+
+func TestMapCategoryErrorMapsUniqueViolationToValidationError(t *testing.T) {
+	err := mapCategoryError(&pgconn.PgError{Code: "23505"})
+
+	appErr, ok := err.(*AppError)
+	if !ok {
+		t.Fatalf("err = %T, want *AppError", err)
+	}
+	if appErr.Code != CodeValidationError {
+		t.Fatalf("Code = %q, want %q", appErr.Code, CodeValidationError)
+	}
+	if appErr.Message != "category code already exists" {
+		t.Fatalf("Message = %q, want category code already exists", appErr.Message)
+	}
+}

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -12,6 +12,7 @@ type Repository interface {
 	UserRepository
 	HouseholdRepository
 	TransactionRepository
+	CategoryRepository
 }
 
 type UserRepository interface {
@@ -36,6 +37,17 @@ type HouseholdRepository interface {
 type TransactionRepository interface {
 	GetTransactionsByIdWithDetails(context.Context, sqlc.GetTransactionsByIdWithDetailsParams) ([]sqlc.GetTransactionsByIdWithDetailsRow, error)
 	ListTransactions(context.Context, sqlc.ListTransactionsParams) ([]sqlc.ListTransactionsRow, error)
+}
+
+type CategoryRepository interface {
+	CreateCategory(context.Context, sqlc.CreateCategoryParams) (sqlc.Category, error)
+	ListCategories(context.Context, bool) ([]sqlc.Category, error)
+	GetCategoryById(context.Context, int64) (sqlc.Category, error)
+	GetActiveCategoryById(context.Context, int64) (sqlc.Category, error)
+	GetCategoryByCode(context.Context, string) (sqlc.Category, error)
+	GetActiveCategoryByCode(context.Context, string) (sqlc.Category, error)
+	UpdateCategory(context.Context, sqlc.UpdateCategoryParams) (sqlc.Category, error)
+	DeactivateCategory(context.Context, string) (sqlc.Category, error)
 }
 
 type TransactionService interface {

--- a/internal/app/test_fakes_test.go
+++ b/internal/app/test_fakes_test.go
@@ -23,6 +23,7 @@ type fakeRepo struct {
 	lastTelegramID       *string
 	lastListTransactions sqlc.ListTransactionsParams
 	transactionDetails   []sqlc.GetTransactionsByIdWithDetailsRow
+	listTransactionRows  []sqlc.ListTransactionsRow
 
 	lastCreateCategory                sqlc.CreateCategoryParams
 	lastUpdateCategory                sqlc.UpdateCategoryParams
@@ -104,7 +105,7 @@ func (f *fakeRepo) GetTransactionsByIdWithDetails(context.Context, sqlc.GetTrans
 
 func (f *fakeRepo) ListTransactions(_ context.Context, arg sqlc.ListTransactionsParams) ([]sqlc.ListTransactionsRow, error) {
 	f.lastListTransactions = arg
-	return nil, nil
+	return f.listTransactionRows, nil
 }
 
 func (f *fakeRepo) CreateCategory(_ context.Context, arg sqlc.CreateCategoryParams) (sqlc.Category, error) {
@@ -124,8 +125,8 @@ func (f *fakeRepo) GetCategoryById(context.Context, int64) (sqlc.Category, error
 	return f.categoryByID, nil
 }
 
-func (f *fakeRepo) GetActiveCategoryById(context.Context, int64) (sqlc.Category, error) {
-	if f.categoryByID.ID == 0 || !f.categoryByID.IsActive {
+func (f *fakeRepo) GetActiveCategoryById(_ context.Context, id int64) (sqlc.Category, error) {
+	if f.categoryByID.ID == 0 || f.categoryByID.ID != id || !f.categoryByID.IsActive {
 		return sqlc.Category{}, sql.ErrNoRows
 	}
 	return f.categoryByID, nil
@@ -138,8 +139,8 @@ func (f *fakeRepo) GetCategoryByCode(context.Context, string) (sqlc.Category, er
 	return f.categoryByCode, nil
 }
 
-func (f *fakeRepo) GetActiveCategoryByCode(context.Context, string) (sqlc.Category, error) {
-	if f.categoryByCode.ID == 0 || !f.categoryByCode.IsActive {
+func (f *fakeRepo) GetActiveCategoryByCode(_ context.Context, code string) (sqlc.Category, error) {
+	if f.categoryByCode.ID == 0 || f.categoryByCode.Code != code || !f.categoryByCode.IsActive {
 		return sqlc.Category{}, sql.ErrNoRows
 	}
 	return f.categoryByCode, nil
@@ -168,6 +169,7 @@ func (f *fakeRepo) DeactivateCategory(context.Context, string) (sqlc.Category, e
 
 type fakeTransactionService struct {
 	saved         []sqlc.CreateTransactionParams
+	updated       []transaction.UpdateTransactionById
 	saveResult    transaction.TransactionResult
 	updateResult  transaction.TransactionResult
 	deleteResult  transaction.TransactionResult
@@ -186,7 +188,8 @@ func (f *fakeTransactionService) SaveTransactions(_ context.Context, transaction
 	return f.saveResult
 }
 
-func (f *fakeTransactionService) UpdateTransactionsById(context.Context, []transaction.UpdateTransactionById) transaction.TransactionResult {
+func (f *fakeTransactionService) UpdateTransactionsById(_ context.Context, transactions []transaction.UpdateTransactionById) transaction.TransactionResult {
+	f.updated = transactions
 	return f.updateResult
 }
 

--- a/internal/app/test_fakes_test.go
+++ b/internal/app/test_fakes_test.go
@@ -23,6 +23,13 @@ type fakeRepo struct {
 	lastTelegramID       *string
 	lastListTransactions sqlc.ListTransactionsParams
 	transactionDetails   []sqlc.GetTransactionsByIdWithDetailsRow
+
+	lastCreateCategory                sqlc.CreateCategoryParams
+	lastUpdateCategory                sqlc.UpdateCategoryParams
+	lastListCategoriesIncludeInactive bool
+	categoryByID                      sqlc.Category
+	categoryByCode                    sqlc.Category
+	listCategoriesResult              []sqlc.Category
 }
 
 func (f *fakeRepo) CreateUser(_ context.Context, arg sqlc.CreateUserParams) (sqlc.User, error) {
@@ -98,6 +105,65 @@ func (f *fakeRepo) GetTransactionsByIdWithDetails(context.Context, sqlc.GetTrans
 func (f *fakeRepo) ListTransactions(_ context.Context, arg sqlc.ListTransactionsParams) ([]sqlc.ListTransactionsRow, error) {
 	f.lastListTransactions = arg
 	return nil, nil
+}
+
+func (f *fakeRepo) CreateCategory(_ context.Context, arg sqlc.CreateCategoryParams) (sqlc.Category, error) {
+	f.lastCreateCategory = arg
+	return sqlc.Category{ID: 1, Code: arg.Code, Name: arg.Name, Description: arg.Description, IsActive: true}, nil
+}
+
+func (f *fakeRepo) ListCategories(_ context.Context, includeInactive bool) ([]sqlc.Category, error) {
+	f.lastListCategoriesIncludeInactive = includeInactive
+	return f.listCategoriesResult, nil
+}
+
+func (f *fakeRepo) GetCategoryById(context.Context, int64) (sqlc.Category, error) {
+	if f.categoryByID.ID == 0 {
+		return sqlc.Category{}, sql.ErrNoRows
+	}
+	return f.categoryByID, nil
+}
+
+func (f *fakeRepo) GetActiveCategoryById(context.Context, int64) (sqlc.Category, error) {
+	if f.categoryByID.ID == 0 || !f.categoryByID.IsActive {
+		return sqlc.Category{}, sql.ErrNoRows
+	}
+	return f.categoryByID, nil
+}
+
+func (f *fakeRepo) GetCategoryByCode(context.Context, string) (sqlc.Category, error) {
+	if f.categoryByCode.ID == 0 {
+		return sqlc.Category{}, sql.ErrNoRows
+	}
+	return f.categoryByCode, nil
+}
+
+func (f *fakeRepo) GetActiveCategoryByCode(context.Context, string) (sqlc.Category, error) {
+	if f.categoryByCode.ID == 0 || !f.categoryByCode.IsActive {
+		return sqlc.Category{}, sql.ErrNoRows
+	}
+	return f.categoryByCode, nil
+}
+
+func (f *fakeRepo) UpdateCategory(_ context.Context, arg sqlc.UpdateCategoryParams) (sqlc.Category, error) {
+	f.lastUpdateCategory = arg
+	name := arg.Name
+	if !arg.SetName {
+		name = f.categoryByID.Name
+	}
+	description := arg.Description
+	if !arg.SetDescription {
+		description = f.categoryByID.Description
+	}
+	return sqlc.Category{ID: arg.ID, Code: f.categoryByID.Code, Name: name, Description: description, IsActive: true}, nil
+}
+
+func (f *fakeRepo) DeactivateCategory(context.Context, string) (sqlc.Category, error) {
+	if f.categoryByCode.ID == 0 {
+		return sqlc.Category{}, sql.ErrNoRows
+	}
+	f.categoryByCode.IsActive = false
+	return f.categoryByCode, nil
 }
 
 type fakeTransactionService struct {

--- a/internal/app/transactions.go
+++ b/internal/app/transactions.go
@@ -12,29 +12,31 @@ import (
 )
 
 type TransactionDTO struct {
-	ID              int64      `json:"id"`
-	Amount          float32    `json:"amount"`
-	TransactionDate time.Time  `json:"transactionDate"`
-	AuthorID        int64      `json:"authorId"`
-	AuthorName      string     `json:"authorName,omitempty"`
-	HouseholdID     *int64     `json:"householdId,omitempty"`
-	HouseholdName   *string    `json:"householdName,omitempty"`
-	Description     *string    `json:"description,omitempty"`
-	Notes           *string    `json:"notes,omitempty"`
-	CreatedAt       *time.Time `json:"createdAt,omitempty"`
-	UpdatedAt       *time.Time `json:"updatedAt,omitempty"`
-	DeletedAt       *time.Time `json:"deletedAt,omitempty"`
-	DeleteReason    *string    `json:"deleteReason,omitempty"`
+	ID              int64           `json:"id"`
+	Amount          float32         `json:"amount"`
+	TransactionDate time.Time       `json:"transactionDate"`
+	AuthorID        int64           `json:"authorId"`
+	AuthorName      string          `json:"authorName,omitempty"`
+	HouseholdID     *int64          `json:"householdId,omitempty"`
+	HouseholdName   *string         `json:"householdName,omitempty"`
+	Category        *CategoryRefDTO `json:"category,omitempty"`
+	Description     *string         `json:"description,omitempty"`
+	Notes           *string         `json:"notes,omitempty"`
+	CreatedAt       *time.Time      `json:"createdAt,omitempty"`
+	UpdatedAt       *time.Time      `json:"updatedAt,omitempty"`
+	DeletedAt       *time.Time      `json:"deletedAt,omitempty"`
+	DeleteReason    *string         `json:"deleteReason,omitempty"`
 }
 
 type CreateTransactionRequest struct {
-	Amount           float32          `json:"amount"`
-	TransactionDate  time.Time        `json:"transactionDate"`
-	Description      *string          `json:"description,omitempty"`
-	Notes            *string          `json:"notes,omitempty"`
-	BudgetCategoryID *int64           `json:"budgetCategoryId,omitempty"`
-	HouseholdID      *int64           `json:"householdId,omitempty"`
-	Author           IdentitySelector `json:"author"`
+	Amount          float32          `json:"amount"`
+	TransactionDate time.Time        `json:"transactionDate"`
+	Description     *string          `json:"description,omitempty"`
+	Notes           *string          `json:"notes,omitempty"`
+	CategoryID      *int64           `json:"categoryId,omitempty"`
+	CategoryCode    *string          `json:"categoryCode,omitempty"`
+	HouseholdID     *int64           `json:"householdId,omitempty"`
+	Author          IdentitySelector `json:"author"`
 }
 
 type BulkCreateTransactionsRequest struct {
@@ -44,18 +46,19 @@ type BulkCreateTransactionsRequest struct {
 type UpdateTransactionRequest struct {
 	ID int64 `json:"id"`
 
-	Amount           *float32          `json:"amount,omitempty"`
-	TransactionDate  *time.Time        `json:"transactionDate,omitempty"`
-	Description      *string           `json:"description,omitempty"`
-	Notes            *string           `json:"notes,omitempty"`
-	BudgetCategoryID *int64            `json:"budgetCategoryId,omitempty"`
-	HouseholdID      *int64            `json:"householdId,omitempty"`
-	Author           *IdentitySelector `json:"author,omitempty"`
+	Amount          *float32          `json:"amount,omitempty"`
+	TransactionDate *time.Time        `json:"transactionDate,omitempty"`
+	Description     *string           `json:"description,omitempty"`
+	Notes           *string           `json:"notes,omitempty"`
+	CategoryID      *int64            `json:"categoryId,omitempty"`
+	CategoryCode    *string           `json:"categoryCode,omitempty"`
+	HouseholdID     *int64            `json:"householdId,omitempty"`
+	Author          *IdentitySelector `json:"author,omitempty"`
 
-	ClearDescription      bool `json:"clearDescription,omitempty"`
-	ClearNotes            bool `json:"clearNotes,omitempty"`
-	ClearBudgetCategoryID bool `json:"clearBudgetCategoryId,omitempty"`
-	ClearHouseholdID      bool `json:"clearHouseholdId,omitempty"`
+	ClearDescription bool `json:"clearDescription,omitempty"`
+	ClearNotes       bool `json:"clearNotes,omitempty"`
+	ClearCategoryID  bool `json:"clearCategoryId,omitempty"`
+	ClearHouseholdID bool `json:"clearHouseholdId,omitempty"`
 }
 
 type BulkUpdateTransactionsRequest struct {
@@ -169,7 +172,7 @@ func (s *Service) GetTransactions(ctx context.Context, ids []int64, includeDelet
 	}
 	dtos := make([]TransactionDTO, 0, len(rows))
 	for _, row := range rows {
-		dtos = append(dtos, transactionDTO(row.Transaction, row.AuthorName, row.HouseholdName))
+		dtos = append(dtos, transactionDTO(row.Transaction, row.AuthorName, row.HouseholdName, row.CategoryID, row.CategoryCode, row.CategoryName))
 	}
 	return dtos, nil
 }
@@ -207,7 +210,7 @@ func (s *Service) ListTransactions(ctx context.Context, req ListTransactionsRequ
 
 	dtos := make([]TransactionDTO, 0, len(rows))
 	for _, row := range rows {
-		dtos = append(dtos, transactionDTO(row.Transaction, row.AuthorName, row.HouseholdName))
+		dtos = append(dtos, transactionDTO(row.Transaction, row.AuthorName, row.HouseholdName, row.CategoryID, row.CategoryCode, row.CategoryName))
 	}
 	return dtos, nil
 }
@@ -252,14 +255,18 @@ func (s *Service) createParams(ctx context.Context, req CreateTransactionRequest
 	if err != nil {
 		return sqlc.CreateTransactionParams{}, err
 	}
+	categoryID, err := s.resolveCategoryID(ctx, req.CategoryID, req.CategoryCode)
+	if err != nil {
+		return sqlc.CreateTransactionParams{}, err
+	}
 	return sqlc.CreateTransactionParams{
-		Amount:           req.Amount,
-		BudgetCategoryID: req.BudgetCategoryID,
-		Description:      req.Description,
-		TransactionDate:  pgtype.Timestamptz{Time: req.TransactionDate, Valid: true},
-		AuthorID:         author.ID,
-		HouseholdID:      req.HouseholdID,
-		Notes:            req.Notes,
+		Amount:          req.Amount,
+		CategoryID:      categoryID,
+		Description:     req.Description,
+		TransactionDate: pgtype.Timestamptz{Time: req.TransactionDate, Valid: true},
+		AuthorID:        author.ID,
+		HouseholdID:     req.HouseholdID,
+		Notes:           req.Notes,
 	}, nil
 }
 
@@ -280,8 +287,14 @@ func (s *Service) updateParams(ctx context.Context, req UpdateTransactionRequest
 	if req.Notes != nil || req.ClearNotes {
 		updates.Notes = utils.NewOptional(req.Notes)
 	}
-	if req.BudgetCategoryID != nil || req.ClearBudgetCategoryID {
-		updates.BudgetCategoryID = utils.NewOptional(req.BudgetCategoryID)
+	if req.CategoryID != nil || req.CategoryCode != nil {
+		categoryID, err := s.resolveCategoryID(ctx, req.CategoryID, req.CategoryCode)
+		if err != nil {
+			return transaction.UpdateTransactionById{}, err
+		}
+		updates.CategoryID = utils.NewOptional(categoryID)
+	} else if req.ClearCategoryID {
+		updates.CategoryID = utils.NewOptional((*int64)(nil))
 	}
 	if req.HouseholdID != nil || req.ClearHouseholdID {
 		updates.HouseholdID = utils.NewOptional(req.HouseholdID)
@@ -296,7 +309,42 @@ func (s *Service) updateParams(ctx context.Context, req UpdateTransactionRequest
 	return transaction.UpdateTransactionById{ID: req.ID, Updates: updates}, nil
 }
 
-func transactionDTO(tx sqlc.Transaction, authorName string, householdName *string) TransactionDTO {
+func (s *Service) resolveCategoryID(ctx context.Context, id *int64, code *string) (*int64, error) {
+	if id == nil && code == nil {
+		return nil, nil
+	}
+
+	if id != nil && code != nil {
+		categoryByID, err := s.repo.GetActiveCategoryById(ctx, *id)
+		if err != nil {
+			return nil, mapCategoryError(err)
+		}
+		categoryByCode, err := s.repo.GetActiveCategoryByCode(ctx, *code)
+		if err != nil {
+			return nil, mapCategoryError(err)
+		}
+		if categoryByID.ID != categoryByCode.ID {
+			return nil, NewError(CodeValidationError, "category id and code refer to different categories", nil)
+		}
+		return &categoryByID.ID, nil
+	}
+
+	if id != nil {
+		category, err := s.repo.GetActiveCategoryById(ctx, *id)
+		if err != nil {
+			return nil, mapCategoryError(err)
+		}
+		return &category.ID, nil
+	}
+
+	category, err := s.repo.GetActiveCategoryByCode(ctx, *code)
+	if err != nil {
+		return nil, mapCategoryError(err)
+	}
+	return &category.ID, nil
+}
+
+func transactionDTO(tx sqlc.Transaction, authorName string, householdName *string, categoryID *int64, categoryCode, categoryName *string) TransactionDTO {
 	return TransactionDTO{
 		ID:              tx.ID,
 		Amount:          tx.Amount,
@@ -305,6 +353,7 @@ func transactionDTO(tx sqlc.Transaction, authorName string, householdName *strin
 		AuthorName:      authorName,
 		HouseholdID:     tx.HouseholdID,
 		HouseholdName:   householdName,
+		Category:        transactionCategoryDTO(categoryID, categoryCode, categoryName),
 		Description:     tx.Description,
 		Notes:           tx.Notes,
 		CreatedAt:       validTime(tx.CreatedAt.Time, tx.CreatedAt.Valid),
@@ -312,6 +361,13 @@ func transactionDTO(tx sqlc.Transaction, authorName string, householdName *strin
 		DeletedAt:       validTime(tx.DeletedAt.Time, tx.DeletedAt.Valid),
 		DeleteReason:    tx.DeleteReason,
 	}
+}
+
+func transactionCategoryDTO(id *int64, code, name *string) *CategoryRefDTO {
+	if id == nil || code == nil || name == nil {
+		return nil
+	}
+	return &CategoryRefDTO{ID: *id, Code: *code, Name: *name}
 }
 
 func timestamptz(value *time.Time) pgtype.Timestamptz {

--- a/internal/app/transactions_test.go
+++ b/internal/app/transactions_test.go
@@ -46,6 +46,112 @@ func TestCreateTransactionResolvesAuthorAndRequiresHousehold(t *testing.T) {
 	}
 }
 
+func TestCreateTransactionResolvesCategoryCode(t *testing.T) {
+	repo := &fakeRepo{
+		userByID:           sqlc.User{ID: 7, Name: "Rafael"},
+		categoryByCode:     sqlc.Category{ID: 42, Code: "groceries", Name: "Groceries", IsActive: true},
+		categoryByID:       sqlc.Category{ID: 42, Code: "groceries", Name: "Groceries", IsActive: true},
+		transactionDetails: nil,
+	}
+	txSvc := &fakeTransactionService{saveResult: transaction.TransactionResult{Success: map[int64]*sqlc.Transaction{101: {ID: 101}}}}
+	svc := NewService(repo, txSvc)
+
+	result := svc.CreateTransaction(context.Background(), CreateTransactionRequest{
+		Amount:          42.5,
+		TransactionDate: time.Date(2026, 5, 5, 14, 30, 0, 0, time.UTC),
+		CategoryCode:    strPtr("groceries"),
+		Author:          IdentitySelector{AuthorID: intPtr(7)},
+		HouseholdID:     intPtr(1),
+	})
+
+	if len(result.Errors) != 0 {
+		t.Fatalf("Errors = %v, want none", result.Errors)
+	}
+	if len(txSvc.saved) != 1 || txSvc.saved[0].CategoryID == nil || *txSvc.saved[0].CategoryID != 42 {
+		t.Fatalf("saved category = %+v, want category id 42", txSvc.saved)
+	}
+}
+
+func TestCreateTransactionRejectsConflictingCategorySelectors(t *testing.T) {
+	repo := &fakeRepo{
+		userByID:       sqlc.User{ID: 7, Name: "Rafael"},
+		categoryByID:   sqlc.Category{ID: 41, Code: "dining", Name: "Dining", IsActive: true},
+		categoryByCode: sqlc.Category{ID: 42, Code: "groceries", Name: "Groceries", IsActive: true},
+	}
+	txSvc := &fakeTransactionService{}
+	svc := NewService(repo, txSvc)
+
+	result := svc.CreateTransaction(context.Background(), CreateTransactionRequest{
+		Amount:          42.5,
+		TransactionDate: time.Date(2026, 5, 5, 14, 30, 0, 0, time.UTC),
+		CategoryID:      intPtr(41),
+		CategoryCode:    strPtr("groceries"),
+		Author:          IdentitySelector{AuthorID: intPtr(7)},
+		HouseholdID:     intPtr(1),
+	})
+
+	if len(result.Errors) != 1 || result.Errors[0].Code != CodeValidationError {
+		t.Fatalf("Errors = %+v, want validation error", result.Errors)
+	}
+	if result.Errors[0].Message != "category id and code refer to different categories" {
+		t.Fatalf("Message = %q, want category selector conflict", result.Errors[0].Message)
+	}
+	if len(txSvc.saved) != 0 {
+		t.Fatalf("saved = %+v, want no transaction write", txSvc.saved)
+	}
+}
+
+func TestUpdateTransactionAssignsCategory(t *testing.T) {
+	repo := &fakeRepo{
+		categoryByCode: sqlc.Category{ID: 42, Code: "groceries", Name: "Groceries", IsActive: true},
+	}
+	txSvc := &fakeTransactionService{updateResult: transaction.TransactionResult{Success: map[int64]*sqlc.Transaction{101: {ID: 101}}}}
+	svc := NewService(repo, txSvc)
+
+	result := svc.UpdateTransaction(context.Background(), UpdateTransactionRequest{
+		ID:           101,
+		CategoryCode: strPtr("groceries"),
+	})
+
+	if len(result.Errors) != 0 {
+		t.Fatalf("Errors = %v, want none", result.Errors)
+	}
+	if len(txSvc.updated) != 1 {
+		t.Fatalf("updated = %+v, want one transaction update", txSvc.updated)
+	}
+	categoryUpdate := txSvc.updated[0].Updates.CategoryID
+	if !categoryUpdate.Set {
+		t.Fatalf("CategoryID.Set = false, want true")
+	}
+	if categoryUpdate.Value == nil || *categoryUpdate.Value != 42 {
+		t.Fatalf("CategoryID.Value = %v, want 42", categoryUpdate.Value)
+	}
+}
+
+func TestUpdateTransactionClearsCategory(t *testing.T) {
+	txSvc := &fakeTransactionService{updateResult: transaction.TransactionResult{Success: map[int64]*sqlc.Transaction{101: {ID: 101}}}}
+	svc := NewService(&fakeRepo{}, txSvc)
+
+	result := svc.UpdateTransaction(context.Background(), UpdateTransactionRequest{
+		ID:              101,
+		ClearCategoryID: true,
+	})
+
+	if len(result.Errors) != 0 {
+		t.Fatalf("Errors = %v, want none", result.Errors)
+	}
+	if len(txSvc.updated) != 1 {
+		t.Fatalf("updated = %+v, want one transaction update", txSvc.updated)
+	}
+	categoryUpdate := txSvc.updated[0].Updates.CategoryID
+	if !categoryUpdate.Set {
+		t.Fatalf("CategoryID.Set = false, want true")
+	}
+	if categoryUpdate.Value != nil {
+		t.Fatalf("CategoryID.Value = %v, want nil", categoryUpdate.Value)
+	}
+}
+
 func TestBulkCreateReturnsPartialFailure(t *testing.T) {
 	repo := &fakeRepo{userByID: sqlc.User{ID: 7, Name: "Rafael"}}
 	txSvc := &fakeTransactionService{saveResult: transaction.TransactionResult{
@@ -82,6 +188,35 @@ func TestListTransactionsDefaultsToDateDesc(t *testing.T) {
 	}
 }
 
+func TestListTransactionsIncludesCategoryDetails(t *testing.T) {
+	categoryID := int64(42)
+	categoryCode := "groceries"
+	categoryName := "Groceries"
+	repo := &fakeRepo{
+		listTransactionRows: []sqlc.ListTransactionsRow{
+			{
+				Transaction:  sqlc.Transaction{ID: 101, AuthorID: 9, CategoryID: &categoryID},
+				AuthorName:   "CLI Tester",
+				CategoryID:   &categoryID,
+				CategoryCode: &categoryCode,
+				CategoryName: &categoryName,
+			},
+		},
+	}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	txs, err := svc.ListTransactions(context.Background(), ListTransactionsRequest{})
+	if err != nil {
+		t.Fatalf("ListTransactions returned error: %v", err)
+	}
+	if len(txs) != 1 || txs[0].Category == nil {
+		t.Fatalf("transactions = %+v, want category details", txs)
+	}
+	if txs[0].Category.ID != 42 || txs[0].Category.Code != "groceries" || txs[0].Category.Name != "Groceries" {
+		t.Fatalf("category = %+v, want groceries ref", txs[0].Category)
+	}
+}
+
 func TestGetTransactionsIncludesAuthorAndHouseholdNames(t *testing.T) {
 	householdID := int64(1)
 	householdName := "Voltr"
@@ -103,6 +238,39 @@ func TestGetTransactionsIncludesAuthorAndHouseholdNames(t *testing.T) {
 	}
 	if len(txs) != 1 || txs[0].AuthorName != "CLI Tester" || txs[0].HouseholdName == nil || *txs[0].HouseholdName != "Voltr" {
 		t.Fatalf("transactions = %+v, want author and household names", txs)
+	}
+}
+
+func TestGetTransactionsIncludesCategoryDetails(t *testing.T) {
+	householdID := int64(1)
+	householdName := "Voltr"
+	categoryID := int64(42)
+	categoryCode := "groceries"
+	categoryName := "Groceries"
+	repo := &fakeRepo{
+		transactionDetails: []sqlc.GetTransactionsByIdWithDetailsRow{
+			{
+				Transaction:   sqlc.Transaction{ID: 101, AuthorID: 9, HouseholdID: &householdID, CategoryID: &categoryID},
+				AuthorName:    "CLI Tester",
+				HouseholdID:   &householdID,
+				HouseholdName: &householdName,
+				CategoryID:    &categoryID,
+				CategoryCode:  &categoryCode,
+				CategoryName:  &categoryName,
+			},
+		},
+	}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	txs, err := svc.GetTransactions(context.Background(), []int64{101}, false)
+	if err != nil {
+		t.Fatalf("GetTransactions returned error: %v", err)
+	}
+	if len(txs) != 1 || txs[0].Category == nil {
+		t.Fatalf("transactions = %+v, want category details", txs)
+	}
+	if txs[0].Category.ID != 42 || txs[0].Category.Code != "groceries" || txs[0].Category.Name != "Groceries" {
+		t.Fatalf("category = %+v, want groceries ref", txs[0].Category)
 	}
 }
 

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -35,12 +35,19 @@ type AppService interface {
 	GetHousehold(context.Context, app.GetHouseholdRequest) (app.HouseholdDTO, error)
 	ListHouseholds(context.Context) ([]app.HouseholdDTO, error)
 	GetHouseholdUsers(context.Context, int64) ([]app.UserDTO, error)
+
+	CreateCategory(context.Context, app.CreateCategoryRequest) (app.CategoryDTO, error)
+	ListCategories(context.Context, app.ListCategoriesRequest) ([]app.CategoryDTO, error)
+	GetCategoryByCode(context.Context, string) (app.CategoryDTO, error)
+	UpdateCategory(context.Context, app.UpdateCategoryRequest) (app.CategoryDTO, error)
+	DeactivateCategory(context.Context, string) (app.CategoryDTO, error)
 }
 
 type CLI struct {
 	Transactions TransactionsCmd `cmd:"" help:"Manage transactions."`
 	Users        UsersCmd        `cmd:"" help:"Manage users."`
 	Households   HouseholdsCmd   `cmd:"" help:"Read households."`
+	Categories   CategoriesCmd   `cmd:"" help:"Manage transaction categories."`
 }
 
 type runContext struct {
@@ -99,7 +106,7 @@ type TransactionCreateCmd struct {
 	TransactionDate   time.Time `required:"" placeholder:"RFC3339" help:"Transaction timestamp in RFC3339 format, for example 2026-05-05T14:30:00-04:00."`
 	Description       *string   `help:"Short transaction description."`
 	Notes             *string   `help:"Longer transaction notes."`
-	BudgetCategoryID  *int64    `placeholder:"INT-64" help:"Internal budget category ID."`
+	Category          *string   `help:"Category code."`
 	HouseholdID       *int64    `required:"" placeholder:"INT-64" help:"Internal household ID."`
 	AuthorID          *int64    `placeholder:"INT-64" help:"Internal author user ID. Exactly one author selector may be provided."`
 	AuthorDiscordID   *string   `help:"Author Discord user ID. Exactly one author selector may be provided."`
@@ -110,13 +117,13 @@ type TransactionCreateCmd struct {
 
 func (c *TransactionCreateCmd) Run(ctx *runContext) error {
 	result := ctx.svc.CreateTransaction(ctx.Context, app.CreateTransactionRequest{
-		Amount:           c.Amount,
-		TransactionDate:  c.TransactionDate,
-		Description:      c.Description,
-		Notes:            c.Notes,
-		BudgetCategoryID: c.BudgetCategoryID,
-		HouseholdID:      c.HouseholdID,
-		Author:           identity(c.AuthorID, c.AuthorDiscordID, c.AuthorTelegramID, c.AuthorPhoneNumber, c.AuthorWhatsappID),
+		Amount:          c.Amount,
+		TransactionDate: c.TransactionDate,
+		Description:     c.Description,
+		Notes:           c.Notes,
+		CategoryCode:    c.Category,
+		HouseholdID:     c.HouseholdID,
+		Author:          identity(c.AuthorID, c.AuthorDiscordID, c.AuthorTelegramID, c.AuthorPhoneNumber, c.AuthorWhatsappID),
 	})
 	return renderWriteResult(ctx.stdout, result)
 }
@@ -134,38 +141,38 @@ func (c *TransactionCreateBulkCmd) Run(ctx *runContext) error {
 }
 
 type TransactionUpdateCmd struct {
-	ID                    int64      `required:"" help:"Internal transaction ID."`
-	Amount                *float32   `placeholder:"FLOAT-32" help:"Replacement transaction amount, in dollars."`
-	TransactionDate       *time.Time `placeholder:"RFC3339" help:"Replacement transaction timestamp in RFC3339 format, for example 2026-05-05T14:30:00-04:00."`
-	Description           *string    `help:"Replacement short transaction description."`
-	Notes                 *string    `help:"Replacement longer transaction notes."`
-	BudgetCategoryID      *int64     `placeholder:"INT-64" help:"Replacement internal budget category ID."`
-	HouseholdID           *int64     `placeholder:"INT-64" help:"Replacement internal household ID."`
-	AuthorID              *int64     `placeholder:"INT-64" help:"Replacement internal author user ID. Exactly one author selector may be provided."`
-	AuthorDiscordID       *string    `help:"Replacement author Discord user ID. Exactly one author selector may be provided."`
-	AuthorTelegramID      *string    `help:"Replacement author Telegram user ID. Exactly one author selector may be provided."`
-	AuthorPhoneNumber     *string    `help:"Replacement author phone number. Exactly one author selector may be provided."`
-	AuthorWhatsappID      *string    `help:"Replacement author WhatsApp ID. Exactly one author selector may be provided."`
-	ClearDescription      bool       `help:"Clear the transaction description."`
-	ClearNotes            bool       `help:"Clear the transaction notes."`
-	ClearBudgetCategoryID bool       `help:"Clear the budget category ID."`
-	ClearHouseholdID      bool       `help:"Clear the household ID."`
+	ID                int64      `required:"" help:"Internal transaction ID."`
+	Amount            *float32   `placeholder:"FLOAT-32" help:"Replacement transaction amount, in dollars."`
+	TransactionDate   *time.Time `placeholder:"RFC3339" help:"Replacement transaction timestamp in RFC3339 format, for example 2026-05-05T14:30:00-04:00."`
+	Description       *string    `help:"Replacement short transaction description."`
+	Notes             *string    `help:"Replacement longer transaction notes."`
+	Category          *string    `help:"Replacement category code."`
+	HouseholdID       *int64     `placeholder:"INT-64" help:"Replacement internal household ID."`
+	AuthorID          *int64     `placeholder:"INT-64" help:"Replacement internal author user ID. Exactly one author selector may be provided."`
+	AuthorDiscordID   *string    `help:"Replacement author Discord user ID. Exactly one author selector may be provided."`
+	AuthorTelegramID  *string    `help:"Replacement author Telegram user ID. Exactly one author selector may be provided."`
+	AuthorPhoneNumber *string    `help:"Replacement author phone number. Exactly one author selector may be provided."`
+	AuthorWhatsappID  *string    `help:"Replacement author WhatsApp ID. Exactly one author selector may be provided."`
+	ClearDescription  bool       `help:"Clear the transaction description."`
+	ClearNotes        bool       `help:"Clear the transaction notes."`
+	ClearCategory     bool       `help:"Clear the transaction category."`
+	ClearHouseholdID  bool       `help:"Clear the household ID."`
 }
 
 func (c *TransactionUpdateCmd) Run(ctx *runContext) error {
 	selector := identity(c.AuthorID, c.AuthorDiscordID, c.AuthorTelegramID, c.AuthorPhoneNumber, c.AuthorWhatsappID)
 	req := app.UpdateTransactionRequest{
-		ID:                    c.ID,
-		Amount:                c.Amount,
-		TransactionDate:       c.TransactionDate,
-		Description:           c.Description,
-		Notes:                 c.Notes,
-		BudgetCategoryID:      c.BudgetCategoryID,
-		HouseholdID:           c.HouseholdID,
-		ClearDescription:      c.ClearDescription,
-		ClearNotes:            c.ClearNotes,
-		ClearBudgetCategoryID: c.ClearBudgetCategoryID,
-		ClearHouseholdID:      c.ClearHouseholdID,
+		ID:               c.ID,
+		Amount:           c.Amount,
+		TransactionDate:  c.TransactionDate,
+		Description:      c.Description,
+		Notes:            c.Notes,
+		CategoryCode:     c.Category,
+		HouseholdID:      c.HouseholdID,
+		ClearDescription: c.ClearDescription,
+		ClearNotes:       c.ClearNotes,
+		ClearCategoryID:  c.ClearCategory,
+		ClearHouseholdID: c.ClearHouseholdID,
 	}
 	if selector != (app.IdentitySelector{}) {
 		req.Author = &selector
@@ -276,6 +283,75 @@ func (c *TransactionRestoreCmd) Run(ctx *runContext) error {
 		IDs:              ids,
 		RestoredByUserID: c.RestoredByUserID,
 	}))
+}
+
+type CategoriesCmd struct {
+	Create     CategoryCreateCmd     `cmd:"" help:"Create a category."`
+	List       CategoryListCmd       `cmd:"" help:"List categories."`
+	Rename     CategoryRenameCmd     `cmd:"" help:"Rename a category by code."`
+	Deactivate CategoryDeactivateCmd `cmd:"" help:"Deactivate a category by code."`
+}
+
+type CategoryCreateCmd struct {
+	Name        string  `arg:"" required:"" help:"Category display name."`
+	Code        *string `help:"Stable category code. Defaults to a slug generated from name."`
+	Description *string `help:"Optional category description."`
+}
+
+func (c *CategoryCreateCmd) Run(ctx *runContext) error {
+	category, err := ctx.svc.CreateCategory(ctx.Context, app.CreateCategoryRequest{
+		Name:        c.Name,
+		Code:        c.Code,
+		Description: c.Description,
+	})
+	if err != nil {
+		return err
+	}
+	return RenderJSON(ctx.stdout, category)
+}
+
+type CategoryListCmd struct {
+	IncludeInactive bool `help:"Include inactive categories."`
+}
+
+func (c *CategoryListCmd) Run(ctx *runContext) error {
+	categories, err := ctx.svc.ListCategories(ctx.Context, app.ListCategoriesRequest{IncludeInactive: c.IncludeInactive})
+	if err != nil {
+		return err
+	}
+	return RenderJSON(ctx.stdout, categories)
+}
+
+type CategoryRenameCmd struct {
+	Code string `arg:"" required:"" help:"Existing category code."`
+	Name string `arg:"" required:"" help:"New category display name."`
+}
+
+func (c *CategoryRenameCmd) Run(ctx *runContext) error {
+	existing, err := ctx.svc.GetCategoryByCode(ctx.Context, c.Code)
+	if err != nil {
+		return err
+	}
+	category, err := ctx.svc.UpdateCategory(ctx.Context, app.UpdateCategoryRequest{
+		ID:   existing.ID,
+		Name: &c.Name,
+	})
+	if err != nil {
+		return err
+	}
+	return RenderJSON(ctx.stdout, category)
+}
+
+type CategoryDeactivateCmd struct {
+	Code string `arg:"" required:"" help:"Category code to deactivate."`
+}
+
+func (c *CategoryDeactivateCmd) Run(ctx *runContext) error {
+	category, err := ctx.svc.DeactivateCategory(ctx.Context, c.Code)
+	if err != nil {
+		return err
+	}
+	return RenderJSON(ctx.stdout, category)
 }
 
 type UsersCmd struct {

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -32,6 +32,87 @@ func TestKongTransactionsCreate(t *testing.T) {
 	}
 }
 
+func TestKongTransactionsCreateCategoryFlag(t *testing.T) {
+	svc := &fakeAppService{}
+	code := Run(context.Background(), []string{
+		"transactions", "create",
+		"--amount", "42.50",
+		"--transaction-date", "2026-05-05T14:30:00-04:00",
+		"--author-telegram-id", "123456",
+		"--household-id", "1",
+		"--category", "groceries",
+	}, nil, &bytes.Buffer{}, &bytes.Buffer{}, svc)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if svc.createTransaction.CategoryCode == nil || *svc.createTransaction.CategoryCode != "groceries" {
+		t.Fatalf("category = %v, want groceries", svc.createTransaction.CategoryCode)
+	}
+}
+
+func TestKongTransactionsUpdateClearCategory(t *testing.T) {
+	svc := &fakeAppService{}
+	code := Run(context.Background(), []string{
+		"transactions", "update",
+		"--id", "101",
+		"--clear-category",
+	}, nil, &bytes.Buffer{}, &bytes.Buffer{}, svc)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if !svc.updateTransaction.ClearCategoryID {
+		t.Fatalf("ClearCategoryID = false, want true")
+	}
+}
+
+func TestKongCategoryCreate(t *testing.T) {
+	svc := &fakeAppService{}
+	code := Run(context.Background(), []string{
+		"categories", "create",
+		"Restaurants & Takeout",
+		"--code", "restaurants",
+	}, nil, &bytes.Buffer{}, &bytes.Buffer{}, svc)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if svc.createCategory.Name != "Restaurants & Takeout" || svc.createCategory.Code == nil || *svc.createCategory.Code != "restaurants" {
+		t.Fatalf("createCategory = %+v, want name and explicit code", svc.createCategory)
+	}
+}
+
+func TestKongCategoryListIncludesInactive(t *testing.T) {
+	svc := &fakeAppService{}
+	code := Run(context.Background(), []string{
+		"categories", "list",
+		"--include-inactive",
+	}, nil, &bytes.Buffer{}, &bytes.Buffer{}, svc)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if !svc.listCategories.IncludeInactive {
+		t.Fatalf("IncludeInactive = false, want true")
+	}
+}
+
+func TestKongCategoryDeactivate(t *testing.T) {
+	svc := &fakeAppService{}
+	code := Run(context.Background(), []string{
+		"categories", "deactivate",
+		"restaurants",
+	}, nil, &bytes.Buffer{}, &bytes.Buffer{}, svc)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if svc.deactivateCategoryCode != "restaurants" {
+		t.Fatalf("deactivate code = %q, want restaurants", svc.deactivateCategoryCode)
+	}
+}
+
 func TestKongTransactionsListCSV(t *testing.T) {
 	svc := &fakeAppService{}
 	var out bytes.Buffer
@@ -210,12 +291,17 @@ func normalizeHelp(help string) string {
 }
 
 type fakeAppService struct {
-	createTransaction   app.CreateTransactionRequest
-	listTransactions    app.ListTransactionsRequest
-	listTransactionsErr error
-	deleteTransactions  app.DeleteTransactionsRequest
-	resolveUser         app.IdentitySelector
-	getHousehold        app.GetHouseholdRequest
+	createTransaction      app.CreateTransactionRequest
+	updateTransaction      app.UpdateTransactionRequest
+	listTransactions       app.ListTransactionsRequest
+	listTransactionsErr    error
+	deleteTransactions     app.DeleteTransactionsRequest
+	resolveUser            app.IdentitySelector
+	getHousehold           app.GetHouseholdRequest
+	createCategory         app.CreateCategoryRequest
+	listCategories         app.ListCategoriesRequest
+	updateCategory         app.UpdateCategoryRequest
+	deactivateCategoryCode string
 }
 
 func (f *fakeAppService) CreateTransaction(_ context.Context, req app.CreateTransactionRequest) app.WriteResult {
@@ -227,7 +313,8 @@ func (f *fakeAppService) CreateTransactions(context.Context, app.BulkCreateTrans
 	return app.WriteResult{}
 }
 
-func (f *fakeAppService) UpdateTransaction(context.Context, app.UpdateTransactionRequest) app.WriteResult {
+func (f *fakeAppService) UpdateTransaction(_ context.Context, req app.UpdateTransactionRequest) app.WriteResult {
+	f.updateTransaction = req
 	return app.WriteResult{}
 }
 
@@ -288,4 +375,36 @@ func (f *fakeAppService) ListHouseholds(context.Context) ([]app.HouseholdDTO, er
 
 func (f *fakeAppService) GetHouseholdUsers(context.Context, int64) ([]app.UserDTO, error) {
 	return nil, nil
+}
+
+func (f *fakeAppService) CreateCategory(_ context.Context, req app.CreateCategoryRequest) (app.CategoryDTO, error) {
+	f.createCategory = req
+	code := ""
+	if req.Code != nil {
+		code = *req.Code
+	}
+	return app.CategoryDTO{ID: 1, Code: code, Name: req.Name, IsActive: true}, nil
+}
+
+func (f *fakeAppService) ListCategories(_ context.Context, req app.ListCategoriesRequest) ([]app.CategoryDTO, error) {
+	f.listCategories = req
+	return []app.CategoryDTO{}, nil
+}
+
+func (f *fakeAppService) GetCategoryByCode(context.Context, string) (app.CategoryDTO, error) {
+	return app.CategoryDTO{ID: 1, Code: "groceries", Name: "Groceries", IsActive: true}, nil
+}
+
+func (f *fakeAppService) UpdateCategory(_ context.Context, req app.UpdateCategoryRequest) (app.CategoryDTO, error) {
+	f.updateCategory = req
+	name := ""
+	if req.Name != nil {
+		name = *req.Name
+	}
+	return app.CategoryDTO{ID: req.ID, Code: "groceries", Name: name, IsActive: true}, nil
+}
+
+func (f *fakeAppService) DeactivateCategory(_ context.Context, code string) (app.CategoryDTO, error) {
+	f.deactivateCategoryCode = code
+	return app.CategoryDTO{ID: 1, Code: code, Name: "Groceries", IsActive: false}, nil
 }

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -30,6 +30,7 @@ func RenderTransactionCompact(w io.Writer, tx app.TransactionDTO) error {
 		{"Date", tx.TransactionDate.Format("2006-01-02 15:04")},
 		{"Author", tx.AuthorName},
 		{"Household", stringValue(tx.HouseholdName)},
+		{"Category", categoryValue(tx.Category)},
 		{"Description", stringValue(tx.Description)},
 		{"Notes", stringValue(tx.Notes)},
 	}
@@ -51,6 +52,8 @@ func RenderTransactionsCSV(w io.Writer, txs []app.TransactionDTO) error {
 		"author_name",
 		"household_id",
 		"household_name",
+		"category_code",
+		"category_name",
 		"description",
 		"notes",
 		"created_at",
@@ -68,6 +71,8 @@ func RenderTransactionsCSV(w io.Writer, txs []app.TransactionDTO) error {
 			tx.AuthorName,
 			formatInt(tx.HouseholdID),
 			stringValue(tx.HouseholdName),
+			categoryCode(tx.Category),
+			categoryValue(tx.Category),
 			stringValue(tx.Description),
 			stringValue(tx.Notes),
 			formatTime(tx.CreatedAt),
@@ -86,6 +91,20 @@ func stringValue(value *string) string {
 		return ""
 	}
 	return *value
+}
+
+func categoryCode(category *app.CategoryRefDTO) string {
+	if category == nil {
+		return ""
+	}
+	return category.Code
+}
+
+func categoryValue(category *app.CategoryRefDTO) string {
+	if category == nil {
+		return ""
+	}
+	return category.Name
 }
 
 func formatInt(value *int64) string {

--- a/internal/cli/render_test.go
+++ b/internal/cli/render_test.go
@@ -36,6 +36,7 @@ func TestRenderSingleTransactionCompact(t *testing.T) {
 		"Date: 2026-05-05 14:30",
 		"Author: Rafael",
 		"Household: Home",
+		"Category: ",
 		"Description: Groceries",
 		"Notes: Costco",
 		"",
@@ -65,7 +66,7 @@ func TestRenderTransactionsCSVUsesStableColumns(t *testing.T) {
 	}
 
 	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
-	wantHeader := "id,amount,transaction_date,author_id,author_name,household_id,household_name,description,notes,created_at,deleted_at"
+	wantHeader := "id,amount,transaction_date,author_id,author_name,household_id,household_name,category_code,category_name,description,notes,created_at,deleted_at"
 	if lines[0] != wantHeader {
 		t.Fatalf("header = %q, want %q", lines[0], wantHeader)
 	}

--- a/internal/database/query.sql
+++ b/internal/database/query.sql
@@ -1,3 +1,58 @@
+-- ******************* category *******************
+-- WRITES
+
+-- name: CreateCategory :one
+INSERT INTO category (code, name, description)
+VALUES ($1, $2, $3)
+RETURNING *;
+
+-- READS
+
+-- name: ListCategories :many
+SELECT * FROM category
+WHERE (sqlc.arg(include_inactive)::bool OR is_active)
+ORDER BY name ASC, id ASC;
+
+-- name: GetCategoryById :one
+SELECT * FROM category
+WHERE id = $1;
+
+-- name: GetActiveCategoryById :one
+SELECT * FROM category
+WHERE id = $1 AND is_active;
+
+-- name: GetCategoryByCode :one
+SELECT * FROM category
+WHERE code = $1;
+
+-- name: GetActiveCategoryByCode :one
+SELECT * FROM category
+WHERE code = $1 AND is_active;
+
+-- WRITES
+
+-- name: UpdateCategory :one
+UPDATE category
+SET
+    name = CASE
+        WHEN sqlc.arg(set_name)::bool THEN sqlc.arg(name)::VARCHAR
+        ELSE name
+    END,
+    description = CASE
+        WHEN sqlc.arg(set_description)::bool THEN sqlc.narg(description)::TEXT
+        ELSE description
+    END,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = sqlc.arg(id)::BIGINT
+RETURNING *;
+
+-- name: DeactivateCategory :one
+UPDATE category
+SET is_active = false,
+    updated_at = CURRENT_TIMESTAMP
+WHERE code = $1
+RETURNING *;
+
 -- ******************* transaction *******************
 -- READS
 
@@ -24,10 +79,14 @@ SELECT
     u.id AS author_id,
     u.name AS author_name,
     h.id AS household_id,
-    h.name AS household_name
+    h.name AS household_name,
+    c.id AS category_id,
+    c.code AS category_code,
+    c.name AS category_name
 FROM transaction t
 JOIN users u ON u.id = t.author_id
 LEFT JOIN household h ON h.id = t.household_id
+LEFT JOIN category c ON c.id = t.category_id
 WHERE t.id = ANY(sqlc.arg(ids)::BIGINT[])
   AND (sqlc.arg(include_deleted)::bool OR t.deleted_at IS NULL)
 ORDER BY array_position(sqlc.arg(ids)::BIGINT[], t.id);
@@ -47,10 +106,14 @@ SELECT
     u.id AS author_id,
     u.name AS author_name,
     h.id AS household_id,
-    h.name AS household_name
+    h.name AS household_name,
+    c.id AS category_id,
+    c.code AS category_code,
+    c.name AS category_name
 FROM transaction t
 JOIN users u ON u.id = t.author_id
 LEFT JOIN household h ON h.id = t.household_id
+LEFT JOIN category c ON c.id = t.category_id
 WHERE
     (NOT sqlc.arg(only_deleted)::bool OR t.deleted_at IS NOT NULL)
     AND (sqlc.arg(include_deleted)::bool OR sqlc.arg(only_deleted)::bool OR t.deleted_at IS NULL)
@@ -83,7 +146,7 @@ OFFSET sqlc.arg(result_offset)::INT;
 INSERT INTO transaction
 (
     amount,
-    budget_category_id,
+    category_id,
     description,
     transaction_date,
     transaction_id,
@@ -107,9 +170,9 @@ SET
         WHEN sqlc.arg(set_author_id)::bool THEN sqlc.arg(author_id)::BIGINT
         ELSE author_id
     END,
-    budget_category_id = CASE
-        WHEN sqlc.arg(set_budget_category_id)::bool THEN sqlc.narg(budget_category_id)::BIGINT
-        ELSE budget_category_id
+    category_id = CASE
+        WHEN sqlc.arg(set_category_id)::bool THEN sqlc.narg(category_id)::BIGINT
+        ELSE category_id
     END,
     description = CASE
         WHEN sqlc.arg(set_description)::bool THEN sqlc.narg(description)::text

--- a/internal/database/sqlc/models.go
+++ b/internal/database/sqlc/models.go
@@ -21,18 +21,14 @@ type Budget struct {
 	UpdatedAt   pgtype.Timestamptz `json:"updatedAt"`
 }
 
-// Breaks down a budget into specific spending areas with allocated funds.
-type BudgetCategory struct {
-	// Internal unique identifier for the budget category.
-	ID int64 `json:"id"`
-	// Reference to the parent budget.
-	BudgetID *int64 `json:"budgetId"`
-	// The label for the spending category (e.g., Groceries, Rent).
-	CategoryName string `json:"categoryName"`
-	// The total amount of currency allocated to this category.
-	Allocation float32            `json:"allocation"`
-	CreatedAt  pgtype.Timestamptz `json:"createdAt"`
-	UpdatedAt  pgtype.Timestamptz `json:"updatedAt"`
+type Category struct {
+	ID          int64              `json:"id"`
+	Code        string             `json:"code"`
+	Name        string             `json:"name"`
+	Description *string            `json:"description"`
+	IsActive    bool               `json:"isActive"`
+	CreatedAt   pgtype.Timestamptz `json:"createdAt"`
+	UpdatedAt   pgtype.Timestamptz `json:"updatedAt"`
 }
 
 // Groups users together into a shared financial unit, linked to a Discord server.
@@ -88,8 +84,6 @@ type Transaction struct {
 	Amount float32 `json:"amount"`
 	// The user who created or is responsible for the transaction.
 	AuthorID int64 `json:"authorId"`
-	// Optional reference to link the transaction to a budget category.
-	BudgetCategoryID *int64 `json:"budgetCategoryId"`
 	// A short summary of the transaction purpose.
 	Description *string `json:"description"`
 	// The actual date and time the financial event occurred.
@@ -105,6 +99,7 @@ type Transaction struct {
 	DeletedAt       pgtype.Timestamptz `json:"deletedAt"`
 	DeletedByUserID *int64             `json:"deletedByUserId"`
 	DeleteReason    *string            `json:"deleteReason"`
+	CategoryID      *int64             `json:"categoryId"`
 }
 
 // Stores identity information for individuals linked to Discord accounts.

--- a/internal/database/sqlc/query.sql.go
+++ b/internal/database/sqlc/query.sql.go
@@ -11,6 +11,36 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const createCategory = `-- name: CreateCategory :one
+
+INSERT INTO category (code, name, description)
+VALUES ($1, $2, $3)
+RETURNING id, code, name, description, is_active, created_at, updated_at
+`
+
+type CreateCategoryParams struct {
+	Code        string  `json:"code"`
+	Name        string  `json:"name"`
+	Description *string `json:"description"`
+}
+
+// ******************* category *******************
+// WRITES
+func (q *Queries) CreateCategory(ctx context.Context, arg CreateCategoryParams) (Category, error) {
+	row := q.db.QueryRow(ctx, createCategory, arg.Code, arg.Name, arg.Description)
+	var i Category
+	err := row.Scan(
+		&i.ID,
+		&i.Code,
+		&i.Name,
+		&i.Description,
+		&i.IsActive,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const createLlmMessage = `-- name: CreateLlmMessage :one
 INSERT INTO
     llm_message (session_id, user_id, role, contents, parent_id)
@@ -73,7 +103,7 @@ const createTransaction = `-- name: CreateTransaction :one
 INSERT INTO transaction
 (
     amount,
-    budget_category_id,
+    category_id,
     description,
     transaction_date,
     transaction_id,
@@ -83,25 +113,25 @@ INSERT INTO transaction
 )
 VALUES
 ($1, $2, $3, $4, $5, $6, $7, $8)
-RETURNING id, amount, author_id, budget_category_id, description, transaction_date, transaction_id, household_id, notes, created_at, updated_at, deleted_at, deleted_by_user_id, delete_reason
+RETURNING id, amount, author_id, description, transaction_date, transaction_id, household_id, notes, created_at, updated_at, deleted_at, deleted_by_user_id, delete_reason, category_id
 `
 
 type CreateTransactionParams struct {
-	Amount           float32            `json:"amount"`
-	BudgetCategoryID *int64             `json:"budgetCategoryId"`
-	Description      *string            `json:"description"`
-	TransactionDate  pgtype.Timestamptz `json:"transactionDate"`
-	TransactionID    string             `json:"transactionId"`
-	AuthorID         int64              `json:"authorId"`
-	HouseholdID      *int64             `json:"householdId"`
-	Notes            *string            `json:"notes"`
+	Amount          float32            `json:"amount"`
+	CategoryID      *int64             `json:"categoryId"`
+	Description     *string            `json:"description"`
+	TransactionDate pgtype.Timestamptz `json:"transactionDate"`
+	TransactionID   string             `json:"transactionId"`
+	AuthorID        int64              `json:"authorId"`
+	HouseholdID     *int64             `json:"householdId"`
+	Notes           *string            `json:"notes"`
 }
 
 // WRITES
 func (q *Queries) CreateTransaction(ctx context.Context, arg CreateTransactionParams) (Transaction, error) {
 	row := q.db.QueryRow(ctx, createTransaction,
 		arg.Amount,
-		arg.BudgetCategoryID,
+		arg.CategoryID,
 		arg.Description,
 		arg.TransactionDate,
 		arg.TransactionID,
@@ -114,7 +144,6 @@ func (q *Queries) CreateTransaction(ctx context.Context, arg CreateTransactionPa
 		&i.ID,
 		&i.Amount,
 		&i.AuthorID,
-		&i.BudgetCategoryID,
 		&i.Description,
 		&i.TransactionDate,
 		&i.TransactionID,
@@ -125,6 +154,7 @@ func (q *Queries) CreateTransaction(ctx context.Context, arg CreateTransactionPa
 		&i.DeletedAt,
 		&i.DeletedByUserID,
 		&i.DeleteReason,
+		&i.CategoryID,
 	)
 	return i, err
 }
@@ -165,6 +195,69 @@ func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (User, e
 	return i, err
 }
 
+const deactivateCategory = `-- name: DeactivateCategory :one
+UPDATE category
+SET is_active = false,
+    updated_at = CURRENT_TIMESTAMP
+WHERE code = $1
+RETURNING id, code, name, description, is_active, created_at, updated_at
+`
+
+func (q *Queries) DeactivateCategory(ctx context.Context, code string) (Category, error) {
+	row := q.db.QueryRow(ctx, deactivateCategory, code)
+	var i Category
+	err := row.Scan(
+		&i.ID,
+		&i.Code,
+		&i.Name,
+		&i.Description,
+		&i.IsActive,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getActiveCategoryByCode = `-- name: GetActiveCategoryByCode :one
+SELECT id, code, name, description, is_active, created_at, updated_at FROM category
+WHERE code = $1 AND is_active
+`
+
+func (q *Queries) GetActiveCategoryByCode(ctx context.Context, code string) (Category, error) {
+	row := q.db.QueryRow(ctx, getActiveCategoryByCode, code)
+	var i Category
+	err := row.Scan(
+		&i.ID,
+		&i.Code,
+		&i.Name,
+		&i.Description,
+		&i.IsActive,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getActiveCategoryById = `-- name: GetActiveCategoryById :one
+SELECT id, code, name, description, is_active, created_at, updated_at FROM category
+WHERE id = $1 AND is_active
+`
+
+func (q *Queries) GetActiveCategoryById(ctx context.Context, id int64) (Category, error) {
+	row := q.db.QueryRow(ctx, getActiveCategoryById, id)
+	var i Category
+	err := row.Scan(
+		&i.ID,
+		&i.Code,
+		&i.Name,
+		&i.Description,
+		&i.IsActive,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const getActiveSessionBySourceId = `-- name: GetActiveSessionBySourceId :one
 SELECT
     id, user_id, source_id, created_at, updated_at
@@ -182,6 +275,46 @@ func (q *Queries) GetActiveSessionBySourceId(ctx context.Context, sourceID strin
 		&i.ID,
 		&i.UserID,
 		&i.SourceID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getCategoryByCode = `-- name: GetCategoryByCode :one
+SELECT id, code, name, description, is_active, created_at, updated_at FROM category
+WHERE code = $1
+`
+
+func (q *Queries) GetCategoryByCode(ctx context.Context, code string) (Category, error) {
+	row := q.db.QueryRow(ctx, getCategoryByCode, code)
+	var i Category
+	err := row.Scan(
+		&i.ID,
+		&i.Code,
+		&i.Name,
+		&i.Description,
+		&i.IsActive,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getCategoryById = `-- name: GetCategoryById :one
+SELECT id, code, name, description, is_active, created_at, updated_at FROM category
+WHERE id = $1
+`
+
+func (q *Queries) GetCategoryById(ctx context.Context, id int64) (Category, error) {
+	row := q.db.QueryRow(ctx, getCategoryById, id)
+	var i Category
+	err := row.Scan(
+		&i.ID,
+		&i.Code,
+		&i.Name,
+		&i.Description,
+		&i.IsActive,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -397,7 +530,7 @@ func (q *Queries) GetTableAndColumnMetadata(ctx context.Context, tableNames []st
 
 const getTransactionById = `-- name: GetTransactionById :one
 
-SELECT id, amount, author_id, budget_category_id, description, transaction_date, transaction_id, household_id, notes, created_at, updated_at, deleted_at, deleted_by_user_id, delete_reason FROM transaction
+SELECT id, amount, author_id, description, transaction_date, transaction_id, household_id, notes, created_at, updated_at, deleted_at, deleted_by_user_id, delete_reason, category_id FROM transaction
 WHERE id = $1
 `
 
@@ -410,7 +543,6 @@ func (q *Queries) GetTransactionById(ctx context.Context, id int64) (Transaction
 		&i.ID,
 		&i.Amount,
 		&i.AuthorID,
-		&i.BudgetCategoryID,
 		&i.Description,
 		&i.TransactionDate,
 		&i.TransactionID,
@@ -421,12 +553,13 @@ func (q *Queries) GetTransactionById(ctx context.Context, id int64) (Transaction
 		&i.DeletedAt,
 		&i.DeletedByUserID,
 		&i.DeleteReason,
+		&i.CategoryID,
 	)
 	return i, err
 }
 
 const getTransactionByIdActive = `-- name: GetTransactionByIdActive :one
-SELECT id, amount, author_id, budget_category_id, description, transaction_date, transaction_id, household_id, notes, created_at, updated_at, deleted_at, deleted_by_user_id, delete_reason FROM transaction
+SELECT id, amount, author_id, description, transaction_date, transaction_id, household_id, notes, created_at, updated_at, deleted_at, deleted_by_user_id, delete_reason, category_id FROM transaction
 WHERE id = $1 AND deleted_at IS NULL
 `
 
@@ -437,7 +570,6 @@ func (q *Queries) GetTransactionByIdActive(ctx context.Context, id int64) (Trans
 		&i.ID,
 		&i.Amount,
 		&i.AuthorID,
-		&i.BudgetCategoryID,
 		&i.Description,
 		&i.TransactionDate,
 		&i.TransactionID,
@@ -448,12 +580,13 @@ func (q *Queries) GetTransactionByIdActive(ctx context.Context, id int64) (Trans
 		&i.DeletedAt,
 		&i.DeletedByUserID,
 		&i.DeleteReason,
+		&i.CategoryID,
 	)
 	return i, err
 }
 
 const getTransactionsById = `-- name: GetTransactionsById :many
-SELECT id, amount, author_id, budget_category_id, description, transaction_date, transaction_id, household_id, notes, created_at, updated_at, deleted_at, deleted_by_user_id, delete_reason FROM transaction
+SELECT id, amount, author_id, description, transaction_date, transaction_id, household_id, notes, created_at, updated_at, deleted_at, deleted_by_user_id, delete_reason, category_id FROM transaction
 WHERE id = ANY($1::BIGINT[])
 `
 
@@ -470,7 +603,6 @@ func (q *Queries) GetTransactionsById(ctx context.Context, ids []int64) ([]Trans
 			&i.ID,
 			&i.Amount,
 			&i.AuthorID,
-			&i.BudgetCategoryID,
 			&i.Description,
 			&i.TransactionDate,
 			&i.TransactionID,
@@ -481,6 +613,7 @@ func (q *Queries) GetTransactionsById(ctx context.Context, ids []int64) ([]Trans
 			&i.DeletedAt,
 			&i.DeletedByUserID,
 			&i.DeleteReason,
+			&i.CategoryID,
 		); err != nil {
 			return nil, err
 		}
@@ -493,7 +626,7 @@ func (q *Queries) GetTransactionsById(ctx context.Context, ids []int64) ([]Trans
 }
 
 const getTransactionsByIdActive = `-- name: GetTransactionsByIdActive :many
-SELECT id, amount, author_id, budget_category_id, description, transaction_date, transaction_id, household_id, notes, created_at, updated_at, deleted_at, deleted_by_user_id, delete_reason FROM transaction
+SELECT id, amount, author_id, description, transaction_date, transaction_id, household_id, notes, created_at, updated_at, deleted_at, deleted_by_user_id, delete_reason, category_id FROM transaction
 WHERE id = ANY($1::BIGINT[])
   AND deleted_at IS NULL
 `
@@ -511,7 +644,6 @@ func (q *Queries) GetTransactionsByIdActive(ctx context.Context, ids []int64) ([
 			&i.ID,
 			&i.Amount,
 			&i.AuthorID,
-			&i.BudgetCategoryID,
 			&i.Description,
 			&i.TransactionDate,
 			&i.TransactionID,
@@ -522,6 +654,7 @@ func (q *Queries) GetTransactionsByIdActive(ctx context.Context, ids []int64) ([
 			&i.DeletedAt,
 			&i.DeletedByUserID,
 			&i.DeleteReason,
+			&i.CategoryID,
 		); err != nil {
 			return nil, err
 		}
@@ -535,14 +668,18 @@ func (q *Queries) GetTransactionsByIdActive(ctx context.Context, ids []int64) ([
 
 const getTransactionsByIdWithDetails = `-- name: GetTransactionsByIdWithDetails :many
 SELECT
-    t.id, t.amount, t.author_id, t.budget_category_id, t.description, t.transaction_date, t.transaction_id, t.household_id, t.notes, t.created_at, t.updated_at, t.deleted_at, t.deleted_by_user_id, t.delete_reason,
+    t.id, t.amount, t.author_id, t.description, t.transaction_date, t.transaction_id, t.household_id, t.notes, t.created_at, t.updated_at, t.deleted_at, t.deleted_by_user_id, t.delete_reason, t.category_id,
     u.id AS author_id,
     u.name AS author_name,
     h.id AS household_id,
-    h.name AS household_name
+    h.name AS household_name,
+    c.id AS category_id,
+    c.code AS category_code,
+    c.name AS category_name
 FROM transaction t
 JOIN users u ON u.id = t.author_id
 LEFT JOIN household h ON h.id = t.household_id
+LEFT JOIN category c ON c.id = t.category_id
 WHERE t.id = ANY($1::BIGINT[])
   AND ($2::bool OR t.deleted_at IS NULL)
 ORDER BY array_position($1::BIGINT[], t.id)
@@ -559,6 +696,9 @@ type GetTransactionsByIdWithDetailsRow struct {
 	AuthorName    string      `json:"authorName"`
 	HouseholdID   *int64      `json:"householdId"`
 	HouseholdName *string     `json:"householdName"`
+	CategoryID    *int64      `json:"categoryId"`
+	CategoryCode  *string     `json:"categoryCode"`
+	CategoryName  *string     `json:"categoryName"`
 }
 
 func (q *Queries) GetTransactionsByIdWithDetails(ctx context.Context, arg GetTransactionsByIdWithDetailsParams) ([]GetTransactionsByIdWithDetailsRow, error) {
@@ -574,7 +714,6 @@ func (q *Queries) GetTransactionsByIdWithDetails(ctx context.Context, arg GetTra
 			&i.Transaction.ID,
 			&i.Transaction.Amount,
 			&i.Transaction.AuthorID,
-			&i.Transaction.BudgetCategoryID,
 			&i.Transaction.Description,
 			&i.Transaction.TransactionDate,
 			&i.Transaction.TransactionID,
@@ -585,10 +724,14 @@ func (q *Queries) GetTransactionsByIdWithDetails(ctx context.Context, arg GetTra
 			&i.Transaction.DeletedAt,
 			&i.Transaction.DeletedByUserID,
 			&i.Transaction.DeleteReason,
+			&i.Transaction.CategoryID,
 			&i.AuthorID,
 			&i.AuthorName,
 			&i.HouseholdID,
 			&i.HouseholdName,
+			&i.CategoryID,
+			&i.CategoryCode,
+			&i.CategoryName,
 		); err != nil {
 			return nil, err
 		}
@@ -763,6 +906,42 @@ func (q *Queries) GetUserDetailsByDiscordId(ctx context.Context, discordID *stri
 	return i, err
 }
 
+const listCategories = `-- name: ListCategories :many
+
+SELECT id, code, name, description, is_active, created_at, updated_at FROM category
+WHERE ($1::bool OR is_active)
+ORDER BY name ASC, id ASC
+`
+
+// READS
+func (q *Queries) ListCategories(ctx context.Context, includeInactive bool) ([]Category, error) {
+	rows, err := q.db.Query(ctx, listCategories, includeInactive)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Category
+	for rows.Next() {
+		var i Category
+		if err := rows.Scan(
+			&i.ID,
+			&i.Code,
+			&i.Name,
+			&i.Description,
+			&i.IsActive,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listHouseholds = `-- name: ListHouseholds :many
 SELECT id, name, guild_id, created_at, updated_at FROM household
 ORDER BY name ASC, id ASC
@@ -851,14 +1030,18 @@ func (q *Queries) ListLlmMessagesBySessionId(ctx context.Context, sessionID int6
 
 const listTransactions = `-- name: ListTransactions :many
 SELECT
-    t.id, t.amount, t.author_id, t.budget_category_id, t.description, t.transaction_date, t.transaction_id, t.household_id, t.notes, t.created_at, t.updated_at, t.deleted_at, t.deleted_by_user_id, t.delete_reason,
+    t.id, t.amount, t.author_id, t.description, t.transaction_date, t.transaction_id, t.household_id, t.notes, t.created_at, t.updated_at, t.deleted_at, t.deleted_by_user_id, t.delete_reason, t.category_id,
     u.id AS author_id,
     u.name AS author_name,
     h.id AS household_id,
-    h.name AS household_name
+    h.name AS household_name,
+    c.id AS category_id,
+    c.code AS category_code,
+    c.name AS category_name
 FROM transaction t
 JOIN users u ON u.id = t.author_id
 LEFT JOIN household h ON h.id = t.household_id
+LEFT JOIN category c ON c.id = t.category_id
 WHERE
     (NOT $1::bool OR t.deleted_at IS NOT NULL)
     AND ($2::bool OR $1::bool OR t.deleted_at IS NULL)
@@ -906,6 +1089,9 @@ type ListTransactionsRow struct {
 	AuthorName    string      `json:"authorName"`
 	HouseholdID   *int64      `json:"householdId"`
 	HouseholdName *string     `json:"householdName"`
+	CategoryID    *int64      `json:"categoryId"`
+	CategoryCode  *string     `json:"categoryCode"`
+	CategoryName  *string     `json:"categoryName"`
 }
 
 func (q *Queries) ListTransactions(ctx context.Context, arg ListTransactionsParams) ([]ListTransactionsRow, error) {
@@ -933,7 +1119,6 @@ func (q *Queries) ListTransactions(ctx context.Context, arg ListTransactionsPara
 			&i.Transaction.ID,
 			&i.Transaction.Amount,
 			&i.Transaction.AuthorID,
-			&i.Transaction.BudgetCategoryID,
 			&i.Transaction.Description,
 			&i.Transaction.TransactionDate,
 			&i.Transaction.TransactionID,
@@ -944,10 +1129,14 @@ func (q *Queries) ListTransactions(ctx context.Context, arg ListTransactionsPara
 			&i.Transaction.DeletedAt,
 			&i.Transaction.DeletedByUserID,
 			&i.Transaction.DeleteReason,
+			&i.Transaction.CategoryID,
 			&i.AuthorID,
 			&i.AuthorName,
 			&i.HouseholdID,
 			&i.HouseholdName,
+			&i.CategoryID,
+			&i.CategoryCode,
+			&i.CategoryName,
 		); err != nil {
 			return nil, err
 		}
@@ -960,7 +1149,7 @@ func (q *Queries) ListTransactions(ctx context.Context, arg ListTransactionsPara
 }
 
 const listTransactionsByHousehold = `-- name: ListTransactionsByHousehold :many
-SELECT id, amount, author_id, budget_category_id, description, transaction_date, transaction_id, household_id, notes, created_at, updated_at, deleted_at, deleted_by_user_id, delete_reason FROM transaction
+SELECT id, amount, author_id, description, transaction_date, transaction_id, household_id, notes, created_at, updated_at, deleted_at, deleted_by_user_id, delete_reason, category_id FROM transaction
 WHERE transaction_type=2 AND household_id = $1
 `
 
@@ -977,7 +1166,6 @@ func (q *Queries) ListTransactionsByHousehold(ctx context.Context, householdID *
 			&i.ID,
 			&i.Amount,
 			&i.AuthorID,
-			&i.BudgetCategoryID,
 			&i.Description,
 			&i.TransactionDate,
 			&i.TransactionID,
@@ -988,6 +1176,7 @@ func (q *Queries) ListTransactionsByHousehold(ctx context.Context, householdID *
 			&i.DeletedAt,
 			&i.DeletedByUserID,
 			&i.DeleteReason,
+			&i.CategoryID,
 		); err != nil {
 			return nil, err
 		}
@@ -1042,7 +1231,7 @@ SET
     updated_at = CURRENT_TIMESTAMP
 WHERE id = ANY($1::BIGINT[])
   AND deleted_at IS NOT NULL
-RETURNING id, amount, author_id, budget_category_id, description, transaction_date, transaction_id, household_id, notes, created_at, updated_at, deleted_at, deleted_by_user_id, delete_reason
+RETURNING id, amount, author_id, description, transaction_date, transaction_id, household_id, notes, created_at, updated_at, deleted_at, deleted_by_user_id, delete_reason, category_id
 `
 
 func (q *Queries) RestoreTransactionsById(ctx context.Context, ids []int64) ([]Transaction, error) {
@@ -1058,7 +1247,6 @@ func (q *Queries) RestoreTransactionsById(ctx context.Context, ids []int64) ([]T
 			&i.ID,
 			&i.Amount,
 			&i.AuthorID,
-			&i.BudgetCategoryID,
 			&i.Description,
 			&i.TransactionDate,
 			&i.TransactionID,
@@ -1069,6 +1257,7 @@ func (q *Queries) RestoreTransactionsById(ctx context.Context, ids []int64) ([]T
 			&i.DeletedAt,
 			&i.DeletedByUserID,
 			&i.DeleteReason,
+			&i.CategoryID,
 		); err != nil {
 			return nil, err
 		}
@@ -1089,7 +1278,7 @@ SET
     updated_at = CURRENT_TIMESTAMP
 WHERE id = ANY($3::BIGINT[])
   AND deleted_at IS NULL
-RETURNING id, amount, author_id, budget_category_id, description, transaction_date, transaction_id, household_id, notes, created_at, updated_at, deleted_at, deleted_by_user_id, delete_reason
+RETURNING id, amount, author_id, description, transaction_date, transaction_id, household_id, notes, created_at, updated_at, deleted_at, deleted_by_user_id, delete_reason, category_id
 `
 
 type SoftDeleteTransactionsByIdParams struct {
@@ -1111,7 +1300,6 @@ func (q *Queries) SoftDeleteTransactionsById(ctx context.Context, arg SoftDelete
 			&i.ID,
 			&i.Amount,
 			&i.AuthorID,
-			&i.BudgetCategoryID,
 			&i.Description,
 			&i.TransactionDate,
 			&i.TransactionID,
@@ -1122,6 +1310,7 @@ func (q *Queries) SoftDeleteTransactionsById(ctx context.Context, arg SoftDelete
 			&i.DeletedAt,
 			&i.DeletedByUserID,
 			&i.DeleteReason,
+			&i.CategoryID,
 		); err != nil {
 			return nil, err
 		}
@@ -1131,6 +1320,53 @@ func (q *Queries) SoftDeleteTransactionsById(ctx context.Context, arg SoftDelete
 		return nil, err
 	}
 	return items, nil
+}
+
+const updateCategory = `-- name: UpdateCategory :one
+
+UPDATE category
+SET
+    name = CASE
+        WHEN $1::bool THEN $2::VARCHAR
+        ELSE name
+    END,
+    description = CASE
+        WHEN $3::bool THEN $4::TEXT
+        ELSE description
+    END,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = $5::BIGINT
+RETURNING id, code, name, description, is_active, created_at, updated_at
+`
+
+type UpdateCategoryParams struct {
+	SetName        bool    `json:"setName"`
+	Name           string  `json:"name"`
+	SetDescription bool    `json:"setDescription"`
+	Description    *string `json:"description"`
+	ID             int64   `json:"id"`
+}
+
+// WRITES
+func (q *Queries) UpdateCategory(ctx context.Context, arg UpdateCategoryParams) (Category, error) {
+	row := q.db.QueryRow(ctx, updateCategory,
+		arg.SetName,
+		arg.Name,
+		arg.SetDescription,
+		arg.Description,
+		arg.ID,
+	)
+	var i Category
+	err := row.Scan(
+		&i.ID,
+		&i.Code,
+		&i.Name,
+		&i.Description,
+		&i.IsActive,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
 }
 
 const updateMessageContents = `-- name: UpdateMessageContents :exec
@@ -1159,9 +1395,9 @@ SET
         WHEN $5::bool THEN $6::BIGINT
         ELSE author_id
     END,
-    budget_category_id = CASE
+    category_id = CASE
         WHEN $7::bool THEN $8::BIGINT
-        ELSE budget_category_id
+        ELSE category_id
     END,
     description = CASE
         WHEN $9::bool THEN $10::text
@@ -1181,26 +1417,26 @@ SET
     END,
     transaction_id = $2
 WHERE
-    id = $1 RETURNING id, amount, author_id, budget_category_id, description, transaction_date, transaction_id, household_id, notes, created_at, updated_at, deleted_at, deleted_by_user_id, delete_reason
+    id = $1 RETURNING id, amount, author_id, description, transaction_date, transaction_id, household_id, notes, created_at, updated_at, deleted_at, deleted_by_user_id, delete_reason, category_id
 `
 
 type UpdateTransactionByIdParams struct {
-	ID                  int64            `json:"id"`
-	TransactionID       string           `json:"transactionId"`
-	SetAmount           bool             `json:"setAmount"`
-	Amount              float32          `json:"amount"`
-	SetAuthorID         bool             `json:"setAuthorId"`
-	AuthorID            int64            `json:"authorId"`
-	SetBudgetCategoryID bool             `json:"setBudgetCategoryId"`
-	BudgetCategoryID    *int64           `json:"budgetCategoryId"`
-	SetDescription      bool             `json:"setDescription"`
-	Description         *string          `json:"description"`
-	SetTransactionDate  bool             `json:"setTransactionDate"`
-	TransactionDate     pgtype.Timestamp `json:"transactionDate"`
-	SetNotes            bool             `json:"setNotes"`
-	Notes               *string          `json:"notes"`
-	SetHouseholdID      bool             `json:"setHouseholdId"`
-	HouseholdID         *int64           `json:"householdId"`
+	ID                 int64            `json:"id"`
+	TransactionID      string           `json:"transactionId"`
+	SetAmount          bool             `json:"setAmount"`
+	Amount             float32          `json:"amount"`
+	SetAuthorID        bool             `json:"setAuthorId"`
+	AuthorID           int64            `json:"authorId"`
+	SetCategoryID      bool             `json:"setCategoryId"`
+	CategoryID         *int64           `json:"categoryId"`
+	SetDescription     bool             `json:"setDescription"`
+	Description        *string          `json:"description"`
+	SetTransactionDate bool             `json:"setTransactionDate"`
+	TransactionDate    pgtype.Timestamp `json:"transactionDate"`
+	SetNotes           bool             `json:"setNotes"`
+	Notes              *string          `json:"notes"`
+	SetHouseholdID     bool             `json:"setHouseholdId"`
+	HouseholdID        *int64           `json:"householdId"`
 }
 
 func (q *Queries) UpdateTransactionById(ctx context.Context, arg UpdateTransactionByIdParams) (Transaction, error) {
@@ -1211,8 +1447,8 @@ func (q *Queries) UpdateTransactionById(ctx context.Context, arg UpdateTransacti
 		arg.Amount,
 		arg.SetAuthorID,
 		arg.AuthorID,
-		arg.SetBudgetCategoryID,
-		arg.BudgetCategoryID,
+		arg.SetCategoryID,
+		arg.CategoryID,
 		arg.SetDescription,
 		arg.Description,
 		arg.SetTransactionDate,
@@ -1227,7 +1463,6 @@ func (q *Queries) UpdateTransactionById(ctx context.Context, arg UpdateTransacti
 		&i.ID,
 		&i.Amount,
 		&i.AuthorID,
-		&i.BudgetCategoryID,
 		&i.Description,
 		&i.TransactionDate,
 		&i.TransactionID,
@@ -1238,6 +1473,7 @@ func (q *Queries) UpdateTransactionById(ctx context.Context, arg UpdateTransacti
 		&i.DeletedAt,
 		&i.DeletedByUserID,
 		&i.DeleteReason,
+		&i.CategoryID,
 	)
 	return i, err
 }

--- a/internal/transaction/hashing.go
+++ b/internal/transaction/hashing.go
@@ -14,6 +14,7 @@ func generateTransactionHash(
 	description string,
 	transactionDate time.Time,
 	authorId, householdId int64,
+	categoryId *int64,
 	amount float32,
 ) (string, error) {
 	if authorId == 0 && householdId == 0 {
@@ -22,13 +23,24 @@ func generateTransactionHash(
 
 	h := xxhash.New()
 
-	fmt.Fprintf(h, "%s|%d|%d|%d|%.2f",
-		description,
-		transactionDate.Unix(),
-		authorId,
-		householdId,
-		amount,
-	)
+	if categoryId == nil {
+		fmt.Fprintf(h, "%s|%d|%d|%d|%.2f",
+			description,
+			transactionDate.Unix(),
+			authorId,
+			householdId,
+			amount,
+		)
+	} else {
+		fmt.Fprintf(h, "%s|%d|%d|%d|%d|%.2f",
+			description,
+			transactionDate.Unix(),
+			authorId,
+			householdId,
+			*categoryId,
+			amount,
+		)
+	}
 
 	return base62.EncodeToString(h.Sum(nil)), nil
 }
@@ -39,6 +51,7 @@ func generateHashForTransactionCreate(transaction sqlc.CreateTransactionParams) 
 		transaction.TransactionDate.Time,
 		transaction.AuthorID,
 		utils.ValueOrZero(transaction.HouseholdID),
+		transaction.CategoryID,
 		transaction.Amount,
 	)
 }
@@ -69,11 +82,17 @@ func generateHashForTransactionUpdate(transaction sqlc.Transaction, updates *Tra
 		amount = updates.Amount.Value
 	}
 
+	categoryId := transaction.CategoryID
+	if updates.CategoryID.Set {
+		categoryId = updates.CategoryID.Value
+	}
+
 	return generateTransactionHash(
 		utils.ValueOrZero(description),
 		transactionDate,
 		authorId,
 		utils.ValueOrZero(householdId),
+		categoryId,
 		amount,
 	)
 }

--- a/internal/transaction/hashing_test.go
+++ b/internal/transaction/hashing_test.go
@@ -1,0 +1,100 @@
+package transaction
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"rdmm404/voltr-finance/internal/database/sqlc"
+
+	"github.com/cespare/xxhash"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jxskiss/base62"
+)
+
+func TestGenerateHashForTransactionCreatePreservesLegacyFormatWhenUncategorized(t *testing.T) {
+	transactionDate := time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
+	description := "Coffee"
+	householdID := int64(2)
+	params := sqlc.CreateTransactionParams{
+		Amount:          4.25,
+		Description:     &description,
+		TransactionDate: pgtype.Timestamptz{Time: transactionDate, Valid: true},
+		AuthorID:        7,
+		HouseholdID:     &householdID,
+	}
+
+	hash, err := generateHashForTransactionCreate(params)
+	if err != nil {
+		t.Fatalf("generateHashForTransactionCreate returned error: %v", err)
+	}
+
+	want := legacyTransactionHash(description, transactionDate, 7, householdID, 4.25)
+	if hash != want {
+		t.Fatalf("hash = %q, want legacy hash %q", hash, want)
+	}
+}
+
+func TestGenerateHashForTransactionCreateIncludesCategoryWhenSet(t *testing.T) {
+	transactionDate := time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
+	description := "Coffee"
+	householdID := int64(2)
+	categoryID := int64(42)
+	params := sqlc.CreateTransactionParams{
+		Amount:          4.25,
+		CategoryID:      &categoryID,
+		Description:     &description,
+		TransactionDate: pgtype.Timestamptz{Time: transactionDate, Valid: true},
+		AuthorID:        7,
+		HouseholdID:     &householdID,
+	}
+
+	hash, err := generateHashForTransactionCreate(params)
+	if err != nil {
+		t.Fatalf("generateHashForTransactionCreate returned error: %v", err)
+	}
+
+	legacy := legacyTransactionHash(description, transactionDate, 7, householdID, 4.25)
+	withCategory := categorizedTransactionHash(description, transactionDate, 7, householdID, categoryID, 4.25)
+	if hash == legacy {
+		t.Fatalf("hash = %q, want category to participate in duplicate detection", hash)
+	}
+	if hash != withCategory {
+		t.Fatalf("hash = %q, want categorized hash %q", hash, withCategory)
+	}
+}
+
+func TestGenerateHashForTransactionUpdatePreservesLegacyFormatWhenStillUncategorized(t *testing.T) {
+	transactionDate := time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
+	description := "Coffee"
+	householdID := int64(2)
+	existing := sqlc.Transaction{
+		Amount:          4.25,
+		AuthorID:        7,
+		Description:     &description,
+		TransactionDate: pgtype.Timestamptz{Time: transactionDate, Valid: true},
+		HouseholdID:     &householdID,
+	}
+
+	hash, err := generateHashForTransactionUpdate(existing, &TransactionUpdate{})
+	if err != nil {
+		t.Fatalf("generateHashForTransactionUpdate returned error: %v", err)
+	}
+
+	want := legacyTransactionHash(description, transactionDate, 7, householdID, 4.25)
+	if hash != want {
+		t.Fatalf("hash = %q, want legacy hash %q", hash, want)
+	}
+}
+
+func legacyTransactionHash(description string, transactionDate time.Time, authorID, householdID int64, amount float32) string {
+	h := xxhash.New()
+	fmt.Fprintf(h, "%s|%d|%d|%d|%.2f", description, transactionDate.Unix(), authorID, householdID, amount)
+	return base62.EncodeToString(h.Sum(nil))
+}
+
+func categorizedTransactionHash(description string, transactionDate time.Time, authorID, householdID, categoryID int64, amount float32) string {
+	h := xxhash.New()
+	fmt.Fprintf(h, "%s|%d|%d|%d|%d|%.2f", description, transactionDate.Unix(), authorID, householdID, categoryID, amount)
+	return base62.EncodeToString(h.Sum(nil))
+}

--- a/internal/transaction/transaction_service.go
+++ b/internal/transaction/transaction_service.go
@@ -111,22 +111,22 @@ func (ts *TransactionService) UpdateTransactionsById(ctx context.Context, transa
 		}
 
 		params := sqlc.UpdateTransactionByIdParams{
-			ID:                  trans.ID,
-			TransactionID:       transHash,
-			SetAmount:           trans.Updates.Amount.Set,
-			Amount:              trans.Updates.Amount.Value,
-			SetAuthorID:         trans.Updates.AuthorID.Set,
-			AuthorID:            trans.Updates.AuthorID.Value,
-			SetBudgetCategoryID: trans.Updates.BudgetCategoryID.Set,
-			BudgetCategoryID:    trans.Updates.BudgetCategoryID.Value,
-			SetDescription:      trans.Updates.Description.Set,
-			Description:         trans.Updates.Description.Value,
-			SetTransactionDate:  trans.Updates.TransactionDate.Set,
-			TransactionDate:     pgtype.Timestamp{Time: trans.Updates.TransactionDate.Value, Valid: true},
-			SetNotes:            trans.Updates.Notes.Set,
-			Notes:               trans.Updates.Notes.Value,
-			SetHouseholdID:      trans.Updates.HouseholdID.Set,
-			HouseholdID:         trans.Updates.HouseholdID.Value,
+			ID:                 trans.ID,
+			TransactionID:      transHash,
+			SetAmount:          trans.Updates.Amount.Set,
+			Amount:             trans.Updates.Amount.Value,
+			SetAuthorID:        trans.Updates.AuthorID.Set,
+			AuthorID:           trans.Updates.AuthorID.Value,
+			SetCategoryID:      trans.Updates.CategoryID.Set,
+			CategoryID:         trans.Updates.CategoryID.Value,
+			SetDescription:     trans.Updates.Description.Set,
+			Description:        trans.Updates.Description.Value,
+			SetTransactionDate: trans.Updates.TransactionDate.Set,
+			TransactionDate:    pgtype.Timestamp{Time: trans.Updates.TransactionDate.Value, Valid: true},
+			SetNotes:           trans.Updates.Notes.Set,
+			Notes:              trans.Updates.Notes.Value,
+			SetHouseholdID:     trans.Updates.HouseholdID.Set,
+			HouseholdID:        trans.Updates.HouseholdID.Value,
 		}
 
 		updatedTrans, err := ts.repository.UpdateTransactionById(ctx, params)

--- a/internal/transaction/types.go
+++ b/internal/transaction/types.go
@@ -27,13 +27,13 @@ type TransactionResult struct {
 }
 
 type TransactionUpdate struct {
-	Amount           utils.Optional[float32]
-	AuthorID         utils.Optional[int64]
-	BudgetCategoryID utils.Optional[*int64]
-	Description      utils.Optional[*string]
-	TransactionDate  utils.Optional[time.Time]
-	Notes            utils.Optional[*string]
-	HouseholdID      utils.Optional[*int64]
+	Amount          utils.Optional[float32]
+	AuthorID        utils.Optional[int64]
+	CategoryID      utils.Optional[*int64]
+	Description     utils.Optional[*string]
+	TransactionDate utils.Optional[time.Time]
+	Notes           utils.Optional[*string]
+	HouseholdID     utils.Optional[*int64]
 }
 
 type UpdateTransactionById struct {


### PR DESCRIPTION
## Summary
- Add global database-backed categories and replace the old `budget_category` transaction path.
- Add optional category assignment to transactions by category id/code, including response rendering.
- Add category CLI commands plus transaction category flags and render output.

## Test Plan
- `GOCACHE=/tmp/voltr-go-build go test ./... -count=1`