### PR TITLE
[codex] Add monthly budget feature

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -47,7 +47,7 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout io.Writer, 
 
 	repo := sqlc.New(pool)
 	txSvc := transaction.NewTransactionService(pool, repo)
-	appSvc := app.NewService(repo, txSvc)
+	appSvc := app.NewServiceWithTransactor(repo, txSvc, app.NewSQLCTransactor(pool, repo))
 
 	return cli.Run(ctx, cliArgs, stdin, stdout, stderr, appSvc)
 }

--- a/db/migrations/20260510000000_monthly_budgets.sql
+++ b/db/migrations/20260510000000_monthly_budgets.sql
@@ -1,0 +1,93 @@
+-- migrate:up
+SET search_path TO transactions, public;
+
+ALTER TABLE budget DROP COLUMN type;
+ALTER TABLE budget ADD COLUMN period_start DATE;
+ALTER TABLE budget ADD COLUMN period_end DATE;
+ALTER TABLE budget ADD COLUMN source_budget_id BIGINT REFERENCES budget(id);
+
+UPDATE budget
+SET
+    period_start = date_trunc('month', created_at)::DATE,
+    period_end = (date_trunc('month', created_at)::DATE + INTERVAL '1 month - 1 day')::DATE
+WHERE period_start IS NULL OR period_end IS NULL;
+
+ALTER TABLE budget ALTER COLUMN period_start SET NOT NULL;
+ALTER TABLE budget ALTER COLUMN period_end SET NOT NULL;
+
+ALTER TABLE budget ADD CONSTRAINT chk_budget_exactly_one_owner
+CHECK (
+    (household_id IS NOT NULL AND user_id IS NULL)
+    OR
+    (household_id IS NULL AND user_id IS NOT NULL)
+);
+
+ALTER TABLE budget ADD CONSTRAINT chk_budget_valid_period
+CHECK (period_end >= period_start);
+
+CREATE UNIQUE INDEX idx_budget_household_period
+ON budget(household_id, period_start, period_end)
+WHERE household_id IS NOT NULL;
+
+CREATE UNIQUE INDEX idx_budget_user_period
+ON budget(user_id, period_start, period_end)
+WHERE user_id IS NOT NULL;
+
+CREATE INDEX idx_budget_household_period_start
+ON budget(household_id, period_start)
+WHERE household_id IS NOT NULL;
+
+CREATE INDEX idx_budget_user_period_start
+ON budget(user_id, period_start)
+WHERE user_id IS NOT NULL;
+
+CREATE TABLE budget_line (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    budget_id BIGINT NOT NULL REFERENCES budget(id) ON DELETE CASCADE,
+    name VARCHAR NOT NULL,
+    allocation_amount NUMERIC(12, 2) NOT NULL,
+    sort_order INTEGER NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    CHECK (allocation_amount >= 0),
+    UNIQUE (budget_id, id),
+    UNIQUE (budget_id, sort_order)
+);
+
+CREATE TABLE budget_line_category (
+    budget_id BIGINT NOT NULL REFERENCES budget(id) ON DELETE CASCADE,
+    budget_line_id BIGINT NOT NULL,
+    category_id BIGINT NOT NULL REFERENCES category(id),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (budget_line_id, category_id),
+    FOREIGN KEY (budget_id, budget_line_id)
+        REFERENCES budget_line(budget_id, id)
+        ON DELETE CASCADE,
+    UNIQUE (budget_id, category_id)
+);
+
+CREATE INDEX idx_budget_line_category_budget_id
+ON budget_line_category(budget_id);
+
+CREATE INDEX idx_budget_line_category_category_id
+ON budget_line_category(category_id);
+
+-- migrate:down
+SET search_path TO transactions, public;
+
+DROP INDEX IF EXISTS idx_budget_line_category_category_id;
+DROP INDEX IF EXISTS idx_budget_line_category_budget_id;
+DROP TABLE IF EXISTS budget_line_category;
+DROP TABLE IF EXISTS budget_line;
+
+DROP INDEX IF EXISTS idx_budget_user_period_start;
+DROP INDEX IF EXISTS idx_budget_household_period_start;
+DROP INDEX IF EXISTS idx_budget_user_period;
+DROP INDEX IF EXISTS idx_budget_household_period;
+
+ALTER TABLE budget DROP CONSTRAINT IF EXISTS chk_budget_valid_period;
+ALTER TABLE budget DROP CONSTRAINT IF EXISTS chk_budget_exactly_one_owner;
+ALTER TABLE budget DROP COLUMN IF EXISTS source_budget_id;
+ALTER TABLE budget DROP COLUMN IF EXISTS period_end;
+ALTER TABLE budget DROP COLUMN IF EXISTS period_start;
+ALTER TABLE budget ADD COLUMN type VARCHAR(50) NOT NULL DEFAULT 'monthly';

--- a/db/migrations/20260510000000_monthly_budgets.sql
+++ b/db/migrations/20260510000000_monthly_budgets.sql
@@ -8,8 +8,8 @@ ALTER TABLE budget ADD COLUMN source_budget_id BIGINT REFERENCES budget(id);
 
 UPDATE budget
 SET
-    period_start = date_trunc('month', created_at)::DATE,
-    period_end = (date_trunc('month', created_at)::DATE + INTERVAL '1 month - 1 day')::DATE
+    period_start = CURRENT_DATE,
+    period_end = CURRENT_DATE
 WHERE period_start IS NULL OR period_end IS NULL;
 
 ALTER TABLE budget ALTER COLUMN period_start SET NOT NULL;
@@ -54,6 +54,9 @@ CREATE TABLE budget_line (
     UNIQUE (budget_id, sort_order)
 );
 
+CREATE INDEX idx_budget_line_budget_id
+ON budget_line(budget_id);
+
 CREATE TABLE budget_line_category (
     budget_id BIGINT NOT NULL REFERENCES budget(id) ON DELETE CASCADE,
     budget_line_id BIGINT NOT NULL,
@@ -78,6 +81,7 @@ SET search_path TO transactions, public;
 DROP INDEX IF EXISTS idx_budget_line_category_category_id;
 DROP INDEX IF EXISTS idx_budget_line_category_budget_id;
 DROP TABLE IF EXISTS budget_line_category;
+DROP INDEX IF EXISTS idx_budget_line_budget_id;
 DROP TABLE IF EXISTS budget_line;
 
 DROP INDEX IF EXISTS idx_budget_user_period_start;

--- a/db/migrations/20260510000000_monthly_budgets.sql
+++ b/db/migrations/20260510000000_monthly_budgets.sql
@@ -1,6 +1,38 @@
 -- migrate:up
 SET search_path TO transactions, public;
 
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM budget
+        WHERE (household_id IS NULL AND user_id IS NULL)
+           OR (household_id IS NOT NULL AND user_id IS NOT NULL)
+    ) THEN
+        RAISE EXCEPTION 'Legacy budget rows have invalid ownership; clean up legacy budget rows before running this migration.';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM budget
+        WHERE household_id IS NOT NULL AND user_id IS NULL
+        GROUP BY household_id
+        HAVING COUNT(*) > 1
+    ) THEN
+        RAISE EXCEPTION 'Legacy household budgets contain duplicate owners; clean up legacy budget rows before running this migration.';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM budget
+        WHERE user_id IS NOT NULL AND household_id IS NULL
+        GROUP BY user_id
+        HAVING COUNT(*) > 1
+    ) THEN
+        RAISE EXCEPTION 'Legacy user budgets contain duplicate owners; clean up legacy budget rows before running this migration.';
+    END IF;
+END $$;
+
 ALTER TABLE budget DROP COLUMN type;
 ALTER TABLE budget ADD COLUMN period_start DATE;
 ALTER TABLE budget ADD COLUMN period_end DATE;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -34,9 +34,13 @@ CREATE TABLE transactions.budget (
     id bigint NOT NULL,
     user_id bigint,
     household_id bigint,
-    type character varying(50) NOT NULL,
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
-    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    period_start date NOT NULL,
+    period_end date NOT NULL,
+    source_budget_id bigint,
+    CONSTRAINT chk_budget_exactly_one_owner CHECK ((((household_id IS NOT NULL) AND (user_id IS NULL)) OR ((household_id IS NULL) AND (user_id IS NOT NULL)))),
+    CONSTRAINT chk_budget_valid_period CHECK ((period_end >= period_start))
 );
 
 
@@ -74,6 +78,48 @@ COMMENT ON COLUMN transactions.budget.household_id IS 'Optional reference to a h
 
 ALTER TABLE transactions.budget ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY (
     SEQUENCE NAME transactions.budget_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1
+);
+
+
+--
+-- Name: budget_line; Type: TABLE; Schema: transactions; Owner: -
+--
+
+CREATE TABLE transactions.budget_line (
+    id bigint NOT NULL,
+    budget_id bigint NOT NULL,
+    name character varying NOT NULL,
+    allocation_amount numeric(12,2) NOT NULL,
+    sort_order integer NOT NULL,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT budget_line_allocation_amount_check CHECK ((allocation_amount >= (0)::numeric))
+);
+
+
+--
+-- Name: budget_line_category; Type: TABLE; Schema: transactions; Owner: -
+--
+
+CREATE TABLE transactions.budget_line_category (
+    budget_id bigint NOT NULL,
+    budget_line_id bigint NOT NULL,
+    category_id bigint NOT NULL,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: budget_line_id_seq; Type: SEQUENCE; Schema: transactions; Owner: -
+--
+
+ALTER TABLE transactions.budget_line ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY (
+    SEQUENCE NAME transactions.budget_line_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -465,6 +511,46 @@ ALTER TABLE transactions.users ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY 
 
 
 --
+-- Name: budget_line budget_line_budget_id_id_key; Type: CONSTRAINT; Schema: transactions; Owner: -
+--
+
+ALTER TABLE ONLY transactions.budget_line
+    ADD CONSTRAINT budget_line_budget_id_id_key UNIQUE (budget_id, id);
+
+
+--
+-- Name: budget_line budget_line_budget_id_sort_order_key; Type: CONSTRAINT; Schema: transactions; Owner: -
+--
+
+ALTER TABLE ONLY transactions.budget_line
+    ADD CONSTRAINT budget_line_budget_id_sort_order_key UNIQUE (budget_id, sort_order);
+
+
+--
+-- Name: budget_line_category budget_line_category_budget_id_category_id_key; Type: CONSTRAINT; Schema: transactions; Owner: -
+--
+
+ALTER TABLE ONLY transactions.budget_line_category
+    ADD CONSTRAINT budget_line_category_budget_id_category_id_key UNIQUE (budget_id, category_id);
+
+
+--
+-- Name: budget_line_category budget_line_category_pkey; Type: CONSTRAINT; Schema: transactions; Owner: -
+--
+
+ALTER TABLE ONLY transactions.budget_line_category
+    ADD CONSTRAINT budget_line_category_pkey PRIMARY KEY (budget_line_id, category_id);
+
+
+--
+-- Name: budget_line budget_line_pkey; Type: CONSTRAINT; Schema: transactions; Owner: -
+--
+
+ALTER TABLE ONLY transactions.budget_line
+    ADD CONSTRAINT budget_line_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: budget budget_pkey; Type: CONSTRAINT; Schema: transactions; Owner: -
 --
 
@@ -574,6 +660,55 @@ ALTER TABLE ONLY transactions.users
 
 ALTER TABLE ONLY transactions.users
     ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: idx_budget_household_period; Type: INDEX; Schema: transactions; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_budget_household_period ON transactions.budget USING btree (household_id, period_start, period_end) WHERE (household_id IS NOT NULL);
+
+
+--
+-- Name: idx_budget_household_period_start; Type: INDEX; Schema: transactions; Owner: -
+--
+
+CREATE INDEX idx_budget_household_period_start ON transactions.budget USING btree (household_id, period_start) WHERE (household_id IS NOT NULL);
+
+
+--
+-- Name: idx_budget_line_budget_id; Type: INDEX; Schema: transactions; Owner: -
+--
+
+CREATE INDEX idx_budget_line_budget_id ON transactions.budget_line USING btree (budget_id);
+
+
+--
+-- Name: idx_budget_line_category_budget_id; Type: INDEX; Schema: transactions; Owner: -
+--
+
+CREATE INDEX idx_budget_line_category_budget_id ON transactions.budget_line_category USING btree (budget_id);
+
+
+--
+-- Name: idx_budget_line_category_category_id; Type: INDEX; Schema: transactions; Owner: -
+--
+
+CREATE INDEX idx_budget_line_category_category_id ON transactions.budget_line_category USING btree (category_id);
+
+
+--
+-- Name: idx_budget_user_period; Type: INDEX; Schema: transactions; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_budget_user_period ON transactions.budget USING btree (user_id, period_start, period_end) WHERE (user_id IS NOT NULL);
+
+
+--
+-- Name: idx_budget_user_period_start; Type: INDEX; Schema: transactions; Owner: -
+--
+
+CREATE INDEX idx_budget_user_period_start ON transactions.budget USING btree (user_id, period_start) WHERE (user_id IS NOT NULL);
 
 
 --
@@ -711,6 +846,46 @@ ALTER TABLE ONLY transactions.budget
 
 
 --
+-- Name: budget_line budget_line_budget_id_fkey; Type: FK CONSTRAINT; Schema: transactions; Owner: -
+--
+
+ALTER TABLE ONLY transactions.budget_line
+    ADD CONSTRAINT budget_line_budget_id_fkey FOREIGN KEY (budget_id) REFERENCES transactions.budget(id) ON DELETE CASCADE;
+
+
+--
+-- Name: budget_line_category budget_line_category_budget_id_budget_line_id_fkey; Type: FK CONSTRAINT; Schema: transactions; Owner: -
+--
+
+ALTER TABLE ONLY transactions.budget_line_category
+    ADD CONSTRAINT budget_line_category_budget_id_budget_line_id_fkey FOREIGN KEY (budget_id, budget_line_id) REFERENCES transactions.budget_line(budget_id, id) ON DELETE CASCADE;
+
+
+--
+-- Name: budget_line_category budget_line_category_budget_id_fkey; Type: FK CONSTRAINT; Schema: transactions; Owner: -
+--
+
+ALTER TABLE ONLY transactions.budget_line_category
+    ADD CONSTRAINT budget_line_category_budget_id_fkey FOREIGN KEY (budget_id) REFERENCES transactions.budget(id) ON DELETE CASCADE;
+
+
+--
+-- Name: budget_line_category budget_line_category_category_id_fkey; Type: FK CONSTRAINT; Schema: transactions; Owner: -
+--
+
+ALTER TABLE ONLY transactions.budget_line_category
+    ADD CONSTRAINT budget_line_category_category_id_fkey FOREIGN KEY (category_id) REFERENCES transactions.category(id);
+
+
+--
+-- Name: budget budget_source_budget_id_fkey; Type: FK CONSTRAINT; Schema: transactions; Owner: -
+--
+
+ALTER TABLE ONLY transactions.budget
+    ADD CONSTRAINT budget_source_budget_id_fkey FOREIGN KEY (source_budget_id) REFERENCES transactions.budget(id);
+
+
+--
 -- Name: budget budget_user_id_fkey; Type: FK CONSTRAINT; Schema: transactions; Owner: -
 --
 
@@ -813,4 +988,5 @@ INSERT INTO transactions.schema_migrations (version) VALUES
     ('20251130194702'),
     ('20260120030638'),
     ('20260505000000'),
-    ('20260508000000');
+    ('20260508000000'),
+    ('20260510000000');

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 # Voltr Finance CLI
 
-`voltr-finance` is a host-installed CLI for direct Postgres-backed finance operations.
+`voltr-finance` is a host-installed CLI for direct Postgres-backed finance operations. Commands emit JSON unless a command explicitly supports another format.
 
 ## Install
 
@@ -37,76 +37,268 @@ Sample `config.json`:
 
 The connection uses the `transactions` search path. `poolSize` defaults to `5` when omitted or zero.
 
+Examples below use:
+
+```bash
+VOLTR="/tmp/voltr-finance --config /tmp/voltr-finance.json"
+```
+
 ## Transactions
+
+Transaction author selectors are `--author-id`, `--author-discord-id`, `--author-telegram-id`, `--author-phone-number`, and `--author-whatsapp-id`. Creates require exactly one author selector. Updates require exactly one only when changing the author.
 
 Create a transaction:
 
 ```bash
-/tmp/voltr-finance --config /tmp/voltr-finance.json transactions create \
+$VOLTR transactions create \
   --amount 42.50 \
   --transaction-date 2026-05-05T14:30:00-04:00 \
   --description "Groceries" \
   --notes "Costco" \
+  --category groceries \
   --author-telegram-id "123456789" \
   --household-id 1
+```
+
+For negative amounts, use `--amount=-12.34` so the value is not parsed as a flag.
+
+Create transactions in bulk from a file, or omit `--input` to read from stdin:
+
+```bash
+$VOLTR transactions create-bulk --input /tmp/transactions-create.json
+```
+
+Expected JSON shape:
+
+```json
+{
+  "transactions": [
+    {
+      "amount": 42.5,
+      "transactionDate": "2026-05-05T14:30:00-04:00",
+      "description": "Groceries",
+      "notes": "Costco",
+      "categoryCode": "groceries",
+      "householdId": 1,
+      "author": { "TelegramID": "123456789" }
+    }
+  ]
+}
+```
+
+Get transactions by ID:
+
+```bash
+$VOLTR transactions get --ids 101,102,103
+$VOLTR transactions get --ids 101 --format compact
+$VOLTR transactions get --ids 101 --include-deleted
 ```
 
 List matching transactions as JSON:
 
 ```bash
-/tmp/voltr-finance --config /tmp/voltr-finance.json transactions list \
+$VOLTR transactions list \
   --from-date 2026-05-01T00:00:00-04:00 \
   --to-date 2026-05-31T23:59:59-04:00 \
   --search "Groceries" \
   --sort transaction_date \
-  --order desc
+  --order desc \
+  --limit 100 \
+  --offset 0
 ```
 
 List matching transactions as CSV:
 
 ```bash
-/tmp/voltr-finance --config /tmp/voltr-finance.json transactions list \
+$VOLTR transactions list \
   --format csv \
   --household-id 1
+```
+
+Useful list filters:
+
+- `--author-id INT-64`
+- `--household-id INT-64`
+- `--from-date RFC3339`
+- `--to-date RFC3339`
+- `--search STRING`
+- `--include-deleted`
+- `--only-deleted`
+
+Sort fields are `transaction_date`, `created_at`, `amount`, and `id`. Sort order is `asc` or `desc`.
+
+Update one transaction:
+
+```bash
+$VOLTR transactions update \
+  --id 101 \
+  --amount 45.00 \
+  --description "Updated groceries" \
+  --category groceries
+```
+
+Clear nullable fields:
+
+```bash
+$VOLTR transactions update \
+  --id 101 \
+  --clear-description \
+  --clear-notes \
+  --clear-category \
+  --clear-household-id
+```
+
+Update transactions in bulk from a file, or omit `--input` to read from stdin:
+
+```bash
+$VOLTR transactions update-bulk --input /tmp/transactions-update.json
+```
+
+Expected JSON shape:
+
+```json
+{
+  "transactions": [
+    {
+      "id": 101,
+      "amount": 45.0,
+      "categoryCode": "groceries"
+    }
+  ]
+}
 ```
 
 Soft-delete transactions:
 
 ```bash
-/tmp/voltr-finance --config /tmp/voltr-finance.json transactions delete \
+$VOLTR transactions delete \
   --ids 123,124 \
   --reason "duplicate import" \
   --deleted-by-user-id 1
 ```
 
-## Users
-
-Resolve a user by provider identity:
+Restore soft-deleted transactions:
 
 ```bash
-/tmp/voltr-finance --config /tmp/voltr-finance.json users resolve \
+$VOLTR transactions restore \
+  --ids 123,124 \
+  --restored-by-user-id 1
+```
+
+## Users
+
+Create a user:
+
+```bash
+$VOLTR users create \
+  --name "Rafael" \
   --telegram-id "123456789"
 ```
 
-Other supported identity selectors are `--author-id`, `--discord-id`, `--phone-number`, and `--whatsapp-id`.
+Supported external identity flags are `--discord-id`, `--telegram-id`, `--phone-number`, and `--whatsapp-id`.
+
+Update a user:
+
+```bash
+$VOLTR users update \
+  --id 4 \
+  --name "Rafael M" \
+  --discord-id "987654321"
+```
+
+Clear external identities:
+
+```bash
+$VOLTR users update \
+  --id 4 \
+  --clear-discord-id \
+  --clear-telegram-id \
+  --clear-phone-number \
+  --clear-whatsapp-id
+```
+
+Get or list users:
+
+```bash
+$VOLTR users get --id 4
+$VOLTR users list
+```
+
+Resolve a user by exactly one identity selector:
+
+```bash
+$VOLTR users resolve --telegram-id "123456789"
+$VOLTR users resolve --author-id 4
+```
+
+Other supported resolve selectors are `--discord-id`, `--phone-number`, and `--whatsapp-id`.
 
 ## Households
 
-Look up a household by name:
+Look up a household by exactly one selector:
 
 ```bash
-/tmp/voltr-finance --config /tmp/voltr-finance.json households get \
-  --name "Home"
+$VOLTR households get --name "Home"
+$VOLTR households get --id 1
+$VOLTR households get --guild-id "1234567890"
 ```
 
-The returned `id` can be passed to transaction commands as `--household-id`.
+List households and household users:
+
+```bash
+$VOLTR households list
+$VOLTR households users --household-id 1
+```
+
+A household `id` can be passed to transaction commands as `--household-id` and to household budget commands as `--household-id`.
+
+## Categories
+
+Create a category. If `--code` is omitted, the app generates a lowercase slug from the name.
+
+```bash
+$VOLTR categories create "Groceries" \
+  --code groceries \
+  --description "Food and household supplies"
+```
+
+List active categories, or include inactive ones:
+
+```bash
+$VOLTR categories list
+$VOLTR categories list --include-inactive
+```
+
+Rename a category by code:
+
+```bash
+$VOLTR categories rename groceries "Groceries and Supplies"
+```
+
+Deactivate a category by code:
+
+```bash
+$VOLTR categories deactivate groceries
+```
+
+Category codes can be passed to transaction commands as `--category` and to budget line commands as comma-separated `--categories` values.
 
 ## Budgets
+
+Budgets are monthly and owned by exactly one household or user. `--month` uses `YYYY-MM`.
+
+Get an existing household monthly budget:
+
+```bash
+$VOLTR budgets get \
+  --household-id 1 \
+  --month 2026-05
+```
 
 Get or create a household monthly budget. When `--create` is provided and the month does not exist, the app copies the latest prior budget for the same owner. If no prior budget exists, it creates an empty budget.
 
 ```bash
-/tmp/voltr-finance --config /tmp/voltr-finance.json budgets get \
+$VOLTR budgets get \
   --household-id 1 \
   --month 2026-05 \
   --create
@@ -115,40 +307,48 @@ Get or create a household monthly budget. When `--create` is provided and the mo
 Get or create a personal monthly budget:
 
 ```bash
-/tmp/voltr-finance --config /tmp/voltr-finance.json budgets get \
+$VOLTR budgets get \
   --user-id 4 \
   --month 2026-05 \
   --create
 ```
 
-Add a budget line. Category inputs use category codes:
+Add a budget line. Amounts are decimal strings with at most two decimal places. Category inputs use comma-separated category codes. A category can appear on only one line within the same budget.
 
 ```bash
-/tmp/voltr-finance --config /tmp/voltr-finance.json budgets lines add \
+$VOLTR budgets lines add \
   --budget-id 12 \
   --name "Groceries" \
   --amount 800.00 \
-  --categories groceries,costco
+  --categories groceries,costco \
+  --sort-order 10
 ```
 
 Update a budget line by line ID:
 
 ```bash
-/tmp/voltr-finance --config /tmp/voltr-finance.json budgets lines update 44 \
-  --amount 900.00
+$VOLTR budgets lines update 44 \
+  --name "Food" \
+  --amount 900.00 \
+  --categories groceries,restaurants \
+  --sort-order 20
 ```
+
+Passing `--categories` on update replaces the line's category mappings. Passing `--categories ""` clears them.
 
 Delete a budget line by line ID:
 
 ```bash
-/tmp/voltr-finance --config /tmp/voltr-finance.json budgets lines delete 44
+$VOLTR budgets lines delete 44
 ```
 
 Show budget actuals:
 
 ```bash
-/tmp/voltr-finance --config /tmp/voltr-finance.json budgets report 12
+$VOLTR budgets report 12
 ```
+
+The report returns budget metadata, report lines, and totals. Line actuals are derived from categorized transactions in the budget period. Transactions without categories are reported separately in `totals.uncategorizedActualAmount`.
 
 ## Nanobot Mapping
 
@@ -157,7 +357,7 @@ Map Nanobot sender metadata to exactly one CLI identity flag.
 Discord:
 
 ```bash
-/tmp/voltr-finance --config /tmp/voltr-finance.json transactions create \
+$VOLTR transactions create \
   --amount 12.99 \
   --transaction-date 2026-05-05T14:30:00-04:00 \
   --description "Discord purchase" \
@@ -168,7 +368,7 @@ Discord:
 Telegram:
 
 ```bash
-/tmp/voltr-finance --config /tmp/voltr-finance.json users resolve \
+$VOLTR users resolve \
   --telegram-id "${metadata_user_id:-$sender_id}"
 ```
 
@@ -177,7 +377,7 @@ When Nanobot falls back to sender IDs like `123456789|rafael`, the application n
 WhatsApp phone number:
 
 ```bash
-/tmp/voltr-finance --config /tmp/voltr-finance.json transactions create \
+$VOLTR transactions create \
   --amount 18.00 \
   --transaction-date 2026-05-05T14:30:00-04:00 \
   --description "WhatsApp phone sender" \
@@ -188,7 +388,7 @@ WhatsApp phone number:
 WhatsApp LID/JID:
 
 ```bash
-/tmp/voltr-finance --config /tmp/voltr-finance.json transactions create \
+$VOLTR transactions create \
   --amount 18.00 \
   --transaction-date 2026-05-05T14:30:00-04:00 \
   --description "WhatsApp JID sender" \

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -101,6 +101,55 @@ Look up a household by name:
 
 The returned `id` can be passed to transaction commands as `--household-id`.
 
+## Budgets
+
+Get or create a household monthly budget. When `--create` is provided and the month does not exist, the app copies the latest prior budget for the same owner. If no prior budget exists, it creates an empty budget.
+
+```bash
+/tmp/voltr-finance --config /tmp/voltr-finance.json budgets get \
+  --household-id 1 \
+  --month 2026-05 \
+  --create
+```
+
+Get or create a personal monthly budget:
+
+```bash
+/tmp/voltr-finance --config /tmp/voltr-finance.json budgets get \
+  --user-id 4 \
+  --month 2026-05 \
+  --create
+```
+
+Add a budget line. Category inputs use category codes:
+
+```bash
+/tmp/voltr-finance --config /tmp/voltr-finance.json budgets lines add \
+  --budget-id 12 \
+  --name "Groceries" \
+  --amount 800.00 \
+  --categories groceries,costco
+```
+
+Update a budget line by line ID:
+
+```bash
+/tmp/voltr-finance --config /tmp/voltr-finance.json budgets lines update 44 \
+  --amount 900.00
+```
+
+Delete a budget line by line ID:
+
+```bash
+/tmp/voltr-finance --config /tmp/voltr-finance.json budgets lines delete 44
+```
+
+Show budget actuals:
+
+```bash
+/tmp/voltr-finance --config /tmp/voltr-finance.json budgets report 12
+```
+
 ## Nanobot Mapping
 
 Map Nanobot sender metadata to exactly one CLI identity flag.

--- a/docs/hexagonal-architecture.md
+++ b/docs/hexagonal-architecture.md
@@ -1,0 +1,283 @@
+# Potential Hexagonal Architecture Direction
+
+This document captures a possible direction for restructuring Voltr Finance toward a more hexagonal architecture. It is not an immediate migration plan or a requirement to rewrite the codebase. It is a reference for future changes, especially as the CLI moves toward becoming a REST API wrapper instead of talking to Postgres directly.
+
+## Core idea
+
+Hexagonal architecture is about dependency direction:
+
+- application/use-case code should sit at the center;
+- inbound technology, such as CLI, HTTP, Discord, or agent flows, should call into the application;
+- outbound technology, such as Postgres/sqlc, Redis, LLM providers, or external APIs, should be called through application-owned ports;
+- infrastructure should adapt to the application, not the other way around.
+
+In short:
+
+```text
+CLI / HTTP / Discord / Agent
+              ↓
+        application use cases
+              ↓
+    app-owned outbound interfaces
+              ↓
+       Postgres / Redis / LLM / APIs
+```
+
+The app should know about budgets, transactions, users, categories, and rules. It should not need to know that budgets are loaded through `sqlc.GetHouseholdBudgetByPeriodParams` or that cache invalidation is implemented with Redis keys.
+
+## Ports and adapters
+
+A **port** is an interface or API shape owned by the application.
+
+Example outbound port:
+
+```go
+type BudgetRepository interface {
+    GetBudgetByPeriod(ctx context.Context, owner BudgetOwner, period BudgetPeriod) (Budget, error)
+    CreateBudget(ctx context.Context, owner BudgetOwner, period BudgetPeriod, sourceID *int64) (Budget, error)
+}
+```
+
+An **adapter** is a concrete implementation or caller at the edge.
+
+Examples:
+
+- CLI command parsing flags and calling app use cases;
+- HTTP handlers parsing JSON and calling app use cases;
+- Postgres/sqlc repository implementing `BudgetRepository`;
+- Redis-backed cache wrapper around a repository;
+- Genkit/LLM client implementing an app-owned `LLMClient` port.
+
+Inbound adapters usually call the app directly. They do not necessarily implement an app interface. Outbound adapters usually implement app-owned interfaces because the app depends on their capabilities.
+
+## Domain/application models
+
+Models like `BudgetOwner` and `BudgetPeriod` are application concepts, not database concepts.
+
+For example, `BudgetOwner` encodes the invariant that a budget belongs to exactly one owner: either a household or a user. That remains true regardless of whether the data is stored in Postgres, memory, or another system.
+
+In a hexagonal approach, repository ports should receive and return application models, not `sqlc` generated models. The Postgres adapter translates between app models and generated sqlc params/rows.
+
+## Relationship with sqlc
+
+This architecture does **not** replace sqlc.
+
+sqlc should remain the canonical SQL execution layer for Postgres:
+
+- handwritten SQL remains explicit and reviewable;
+- query params and rows remain compile-checked;
+- scanning and generated boilerplate stay automated;
+- complex SQL can stay in SQL instead of being rebuilt through a query builder.
+
+The repository layer should not become a one-for-one wrapper around every sqlc method. That would add ceremony and defeat the purpose.
+
+Instead, introduce app-level repository methods only when generated query shape leaks too much persistence detail into use-case code.
+
+Good candidates:
+
+```go
+GetBudgetByPeriod(ctx, owner, period)
+CreateMonthlyBudgetFromSource(ctx, owner, period, sourceBudgetID)
+ReplaceBudgetLineCategories(ctx, budgetID, lineID, categoryIDs)
+GetBudgetReport(ctx, budgetID)
+```
+
+Poor candidates:
+
+```go
+GetHouseholdBudgetByPeriod(...)
+GetUserBudgetByPeriod(...)
+DeleteBudgetLineCategories(...)
+CreateBudgetLineCategory(...)
+```
+
+The first group describes application operations. The second group mirrors generated SQL details.
+
+## Preferred package shape
+
+We do not need folder names like `adapters/inbound` or `adapters/outbound`. The structure can stay Go-simple while preserving dependency direction.
+
+A possible long-term shape:
+
+```text
+cmd/
+  api/
+    main.go              # wires HTTP server + app + Postgres repositories
+  cli/
+    main.go              # wires CLI + REST API client
+
+internal/
+  app/
+    errors/              # optional shared app errors, if not kept per feature
+      errors.go
+
+    budgets/
+      service.go         # budget use cases
+      models.go          # BudgetOwner, BudgetPeriod, Budget, BudgetLine
+      ports.go           # repository/other outbound ports needed by budgets
+
+    transactions/
+      service.go
+      models.go
+      ports.go
+
+    categories/
+      service.go
+      models.go
+      ports.go
+
+    users/
+      service.go
+      models.go
+      ports.go
+
+  http/
+    server.go
+    budgets.go
+    transactions.go
+    errors.go
+
+  cli/
+    commands.go
+    render.go
+
+  database/
+    conn.go
+    transactor.go
+    budgets.go          # sqlc-backed app.BudgetRepository
+    transactions.go
+    categories.go
+    sqlc/
+      ...generated...
+
+  api/
+    client.go           # REST client used by CLI
+    budgets.go
+    transactions.go
+
+  cache/
+    redis.go            # optional Redis implementations/decorators
+
+  agent/
+    ...                 # optional inbound agent/Discord orchestration if revived
+
+  llm/
+    genkit.go           # optional outbound LLM adapter if app calls an LLM
+```
+
+The important rule is not the folder name. The important rule is dependency direction:
+
+```text
+internal/app/... imports no http, cli, database, api, cache, agent, or llm packages.
+
+internal/http imports specific app feature packages, such as internal/app/budgets.
+internal/database imports app feature packages and internal/database/sqlc.
+internal/cli may import internal/api once the CLI becomes a REST wrapper.
+```
+
+### App feature packages
+
+The app layer should be organized by feature area rather than as one large package:
+
+```text
+internal/app/budgets
+internal/app/transactions
+internal/app/categories
+internal/app/users
+```
+
+Each feature package owns its own use cases, models, and outbound ports. For example, `internal/app/budgets` owns `BudgetOwner`, `BudgetPeriod`, budget request/response models, and the repository interfaces its use cases need.
+
+Be careful with dependencies between sibling app packages. If budgets need category data, prefer defining a small consumer-owned port in `internal/app/budgets`:
+
+```go
+type CategoryResolver interface {
+    ResolveActiveCategoryIDs(ctx context.Context, codes []string) ([]int64, error)
+}
+```
+
+Then the database adapter can implement that port. This avoids making `budgets` import `categories` unless the dependency is truly part of the domain model.
+
+Use shared app packages sparingly. A shared package can make sense for genuinely universal concepts, such as app errors or a future `Money` type, but it should not become a dumping ground for miscellaneous models.
+
+## CLI as REST wrapper
+
+If the CLI becomes a REST API wrapper, the architecture naturally becomes more hexagonal.
+
+Target runtime shape:
+
+```text
+Human
+  ↓
+CLI
+  ↓
+REST API client
+  ↓
+HTTP server
+  ↓
+application use cases
+  ↓
+app-owned repository ports
+  ↓
+Postgres/sqlc repository adapter
+```
+
+The CLI should become thin:
+
+- parse flags;
+- call the REST API;
+- render responses.
+
+The API server owns use-case execution:
+
+- parse HTTP requests;
+- call `internal/app` services;
+- map app errors to HTTP status codes;
+- encode HTTP responses.
+
+## Agent, Discord, and Genkit
+
+If the agent flow is revived, classify it by role:
+
+- Discord receiving messages is an inbound adapter.
+- An agent or assistant use case that decides what product action to take belongs in `internal/app` if it contains business/product behavior.
+- Genkit as an LLM provider is an outbound adapter behind an app-owned interface.
+- Genkit as an externally invoked flow is an inbound adapter that should call app use cases.
+
+Prefer this shape:
+
+```text
+Discord / Genkit flow
+        ↓
+ app Assistant use case
+        ↓
+ budget/transaction/category use cases
+        ↓
+ LLM port, repositories, etc.
+        ↓
+ Genkit adapter, Postgres adapter, etc.
+```
+
+Avoid making one adapter call another adapter for core orchestration. If adapter-to-adapter calls start containing product behavior, move that behavior into `internal/app`.
+
+## Migration philosophy
+
+Do not big-bang rewrite the codebase.
+
+Migrate feature by feature when there is a reason:
+
+- adding the REST API;
+- changing CLI to call the API;
+- fixing service code that is too tightly coupled to sqlc shapes;
+- introducing cache, external services, or LLM integrations;
+- making a use case easier to test.
+
+Rules of thumb:
+
+1. Keep app code centered on use cases and domain/application concepts.
+2. Keep sqlc as the explicit Postgres SQL layer.
+3. Do not wrap sqlc one-for-one.
+4. Add repository methods only when they represent meaningful app operations or read models.
+5. Let app-owned interfaces define what infrastructure must provide.
+6. Let adapters translate between technology-specific shapes and app models.
+7. Prefer boring Go package structure over architecture-diagram purity.

--- a/docs/superpowers/plans/2026-05-10-budget-implementation.md
+++ b/docs/superpowers/plans/2026-05-10-budget-implementation.md
@@ -1,0 +1,2314 @@
+# Budget Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build monthly household and personal budgets with normalized budget lines, category mappings, auto-copy from the latest prior budget, line-level CLI operations, and derived budget reports.
+
+**Architecture:** Budgets are monthly owner-scoped snapshots stored in the existing `budget` table, with `budget_line` and `budget_line_category` tables for planned allocations and category mappings. Transactions remain linked only to categories; budget actuals are derived by joining transaction categories to budget line category mappings for the budget owner and period.
+
+**Tech Stack:** Go, PostgreSQL migrations managed by dbmate, sqlc v1.29, pgx/v5, Kong CLI, standard Go tests.
+
+---
+
+## File Map
+
+- Create `db/migrations/20260510000000_monthly_budgets.sql`: reshape `budget`, add `budget_line`, add `budget_line_category`, and add indexes/constraints.
+- Modify `internal/database/query.sql`: add budget, budget line, budget category mapping, copy, and report queries.
+- Regenerate `internal/database/sqlc/models.go` and `internal/database/sqlc/query.sql.go` with `sqlc generate`.
+- Modify `internal/app/service.go`: add `BudgetRepository` methods to the service repository interface.
+- Create `internal/app/budgets.go`: budget DTOs, request types, monthly period calculation, owner validation, service methods, line validation, copy behavior, and report assembly.
+- Create `internal/app/budgets_test.go`: service-level tests for monthly creation/copying, line operations, validation, and report math.
+- Modify `internal/app/test_fakes_test.go`: add fake budget repository state and methods.
+- Modify `internal/cli/commands.go`: add `budgets` command group and budget methods to `AppService`.
+- Modify `internal/cli/commands_test.go`: add CLI parser tests for `budgets get`, `budgets report`, `budgets lines add`, `budgets lines update`, and `budgets lines delete`.
+- Modify `docs/cli.md`: document basic budget CLI usage.
+
+---
+
+### Task 1: Database Migration and sqlc Queries
+
+**Files:**
+- Create: `db/migrations/20260510000000_monthly_budgets.sql`
+- Modify: `internal/database/query.sql`
+- Generate: `internal/database/sqlc/models.go`
+- Generate: `internal/database/sqlc/query.sql.go`
+
+- [ ] **Step 1: Write the migration**
+
+Create `db/migrations/20260510000000_monthly_budgets.sql`:
+
+```sql
+-- migrate:up
+SET search_path TO transactions, public;
+
+ALTER TABLE budget
+    DROP COLUMN type,
+    ADD COLUMN period_start DATE,
+    ADD COLUMN period_end DATE,
+    ADD COLUMN source_budget_id BIGINT REFERENCES budget(id),
+    ADD CONSTRAINT budget_exactly_one_owner CHECK (
+        (household_id IS NOT NULL AND user_id IS NULL)
+        OR
+        (household_id IS NULL AND user_id IS NOT NULL)
+    ),
+    ADD CONSTRAINT budget_valid_period CHECK (period_end >= period_start);
+
+UPDATE budget
+SET period_start = CURRENT_DATE,
+    period_end = CURRENT_DATE
+WHERE period_start IS NULL
+   OR period_end IS NULL;
+
+ALTER TABLE budget
+    ALTER COLUMN period_start SET NOT NULL,
+    ALTER COLUMN period_end SET NOT NULL;
+
+CREATE UNIQUE INDEX idx_budget_household_period
+ON budget(household_id, period_start, period_end)
+WHERE household_id IS NOT NULL;
+
+CREATE UNIQUE INDEX idx_budget_user_period
+ON budget(user_id, period_start, period_end)
+WHERE user_id IS NOT NULL;
+
+CREATE INDEX idx_budget_household_period_start
+ON budget(household_id, period_start)
+WHERE household_id IS NOT NULL;
+
+CREATE INDEX idx_budget_user_period_start
+ON budget(user_id, period_start)
+WHERE user_id IS NOT NULL;
+
+CREATE TABLE budget_line (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    budget_id BIGINT NOT NULL REFERENCES budget(id) ON DELETE CASCADE,
+    name VARCHAR NOT NULL,
+    allocation_amount NUMERIC(12, 2) NOT NULL,
+    sort_order INTEGER NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    CHECK (allocation_amount >= 0),
+    UNIQUE (budget_id, id),
+    UNIQUE (budget_id, sort_order)
+);
+
+CREATE INDEX idx_budget_line_budget_id
+ON budget_line(budget_id);
+
+CREATE TABLE budget_line_category (
+    budget_id BIGINT NOT NULL REFERENCES budget(id) ON DELETE CASCADE,
+    budget_line_id BIGINT NOT NULL,
+    category_id BIGINT NOT NULL REFERENCES category(id),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (budget_line_id, category_id),
+    FOREIGN KEY (budget_id, budget_line_id)
+        REFERENCES budget_line(budget_id, id)
+        ON DELETE CASCADE,
+    UNIQUE (budget_id, category_id)
+);
+
+CREATE INDEX idx_budget_line_category_budget_id
+ON budget_line_category(budget_id);
+
+CREATE INDEX idx_budget_line_category_category_id
+ON budget_line_category(category_id);
+
+-- migrate:down
+SET search_path TO transactions, public;
+
+DROP INDEX IF EXISTS idx_budget_line_category_category_id;
+DROP INDEX IF EXISTS idx_budget_line_category_budget_id;
+DROP TABLE IF EXISTS budget_line_category;
+
+DROP INDEX IF EXISTS idx_budget_line_budget_id;
+DROP TABLE IF EXISTS budget_line;
+
+DROP INDEX IF EXISTS idx_budget_user_period_start;
+DROP INDEX IF EXISTS idx_budget_household_period_start;
+DROP INDEX IF EXISTS idx_budget_user_period;
+DROP INDEX IF EXISTS idx_budget_household_period;
+
+ALTER TABLE budget
+    DROP CONSTRAINT IF EXISTS budget_valid_period,
+    DROP CONSTRAINT IF EXISTS budget_exactly_one_owner,
+    DROP COLUMN source_budget_id,
+    DROP COLUMN period_end,
+    DROP COLUMN period_start,
+    ADD COLUMN type VARCHAR(50) NOT NULL DEFAULT 'monthly';
+```
+
+- [ ] **Step 2: Run migration syntax generation check**
+
+Run:
+
+```bash
+sqlc generate
+```
+
+Expected: this may fail because `internal/database/query.sql` does not reference the new tables yet, but it must not fail with migration syntax errors.
+
+- [ ] **Step 3: Add budget queries to `internal/database/query.sql`**
+
+Add this section before the transaction section:
+
+```sql
+-- ******************* budget *******************
+-- READS
+
+-- name: GetHouseholdBudgetByPeriod :one
+SELECT * FROM budget
+WHERE household_id = $1
+  AND user_id IS NULL
+  AND period_start = $2
+  AND period_end = $3;
+
+-- name: GetUserBudgetByPeriod :one
+SELECT * FROM budget
+WHERE user_id = $1
+  AND household_id IS NULL
+  AND period_start = $2
+  AND period_end = $3;
+
+-- name: GetBudgetById :one
+SELECT * FROM budget
+WHERE id = $1;
+
+-- name: GetLatestPriorHouseholdBudget :one
+SELECT * FROM budget
+WHERE household_id = $1
+  AND user_id IS NULL
+  AND period_start < $2
+ORDER BY period_start DESC, id DESC
+LIMIT 1;
+
+-- name: GetLatestPriorUserBudget :one
+SELECT * FROM budget
+WHERE user_id = $1
+  AND household_id IS NULL
+  AND period_start < $2
+ORDER BY period_start DESC, id DESC
+LIMIT 1;
+
+-- name: ListBudgetLines :many
+SELECT * FROM budget_line
+WHERE budget_id = $1
+ORDER BY sort_order ASC, id ASC;
+
+-- name: ListBudgetLineCategories :many
+SELECT
+    blc.budget_id,
+    blc.budget_line_id,
+    c.id AS category_id,
+    c.code AS category_code,
+    c.name AS category_name
+FROM budget_line_category blc
+JOIN category c ON c.id = blc.category_id
+WHERE blc.budget_id = $1
+ORDER BY blc.budget_line_id ASC, c.name ASC, c.id ASC;
+
+-- name: GetBudgetLineById :one
+SELECT * FROM budget_line
+WHERE id = $1;
+
+-- name: GetMaxBudgetLineSortOrder :one
+SELECT COALESCE(MAX(sort_order), 0)::INT
+FROM budget_line
+WHERE budget_id = $1;
+
+-- name: ListBudgetTransactions :many
+SELECT
+    t.category_id,
+    SUM(t.amount)::REAL AS actual_amount
+FROM transaction t
+WHERE t.deleted_at IS NULL
+  AND t.category_id IS NOT NULL
+  AND t.transaction_date >= sqlc.arg(period_start)::DATE
+  AND t.transaction_date < (sqlc.arg(period_end)::DATE + INTERVAL '1 day')
+  AND (
+    (sqlc.narg(household_id)::BIGINT IS NOT NULL AND t.household_id = sqlc.narg(household_id)::BIGINT)
+    OR
+    (sqlc.narg(user_id)::BIGINT IS NOT NULL AND t.author_id = sqlc.narg(user_id)::BIGINT)
+  )
+GROUP BY t.category_id;
+
+-- name: SumUncategorizedBudgetTransactions :one
+SELECT COALESCE(SUM(t.amount), 0)::REAL AS actual_amount
+FROM transaction t
+WHERE t.deleted_at IS NULL
+  AND t.category_id IS NULL
+  AND t.transaction_date >= sqlc.arg(period_start)::DATE
+  AND t.transaction_date < (sqlc.arg(period_end)::DATE + INTERVAL '1 day')
+  AND (
+    (sqlc.narg(household_id)::BIGINT IS NOT NULL AND t.household_id = sqlc.narg(household_id)::BIGINT)
+    OR
+    (sqlc.narg(user_id)::BIGINT IS NOT NULL AND t.author_id = sqlc.narg(user_id)::BIGINT)
+  );
+
+-- WRITES
+
+-- name: CreateHouseholdBudget :one
+INSERT INTO budget (household_id, period_start, period_end, source_budget_id)
+VALUES ($1, $2, $3, $4)
+RETURNING *;
+
+-- name: CreateUserBudget :one
+INSERT INTO budget (user_id, period_start, period_end, source_budget_id)
+VALUES ($1, $2, $3, $4)
+RETURNING *;
+
+-- name: CreateBudgetLine :one
+INSERT INTO budget_line (budget_id, name, allocation_amount, sort_order)
+VALUES ($1, $2, $3, $4)
+RETURNING *;
+
+-- name: UpdateBudgetLine :one
+UPDATE budget_line
+SET
+    name = CASE
+        WHEN sqlc.arg(set_name)::bool THEN sqlc.arg(name)::VARCHAR
+        ELSE name
+    END,
+    allocation_amount = CASE
+        WHEN sqlc.arg(set_allocation_amount)::bool THEN sqlc.arg(allocation_amount)::NUMERIC(12, 2)
+        ELSE allocation_amount
+    END,
+    sort_order = CASE
+        WHEN sqlc.arg(set_sort_order)::bool THEN sqlc.arg(sort_order)::INTEGER
+        ELSE sort_order
+    END,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = sqlc.arg(id)::BIGINT
+RETURNING *;
+
+-- name: DeleteBudgetLine :exec
+DELETE FROM budget_line
+WHERE id = $1;
+
+-- name: DeleteBudgetLineCategories :exec
+DELETE FROM budget_line_category
+WHERE budget_line_id = $1;
+
+-- name: CreateBudgetLineCategory :exec
+INSERT INTO budget_line_category (budget_id, budget_line_id, category_id)
+VALUES ($1, $2, $3);
+```
+
+- [ ] **Step 4: Generate sqlc output**
+
+Run:
+
+```bash
+sqlc generate
+```
+
+Expected: exit 0. `internal/database/sqlc/models.go` contains `BudgetLine` and `BudgetLineCategory`, and `Budget` has `PeriodStart`, `PeriodEnd`, and `SourceBudgetID` fields.
+
+- [ ] **Step 5: Commit database and query changes**
+
+Run:
+
+```bash
+git add db/migrations/20260510000000_monthly_budgets.sql internal/database/query.sql internal/database/sqlc
+git commit -m "Add budget schema and queries"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 2: App Budget Types and Monthly Budget Retrieval
+
+**Files:**
+- Modify: `internal/app/service.go`
+- Create: `internal/app/budgets.go`
+- Create: `internal/app/budgets_test.go`
+- Modify: `internal/app/test_fakes_test.go`
+
+- [ ] **Step 1: Add failing tests for owner validation and monthly period calculation**
+
+Create `internal/app/budgets_test.go`:
+
+```go
+package app
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"rdmm404/voltr-finance/internal/database/sqlc"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func TestMonthlyBudgetPeriod(t *testing.T) {
+	start, end, err := monthlyBudgetPeriod(2026, 5)
+	if err != nil {
+		t.Fatalf("monthlyBudgetPeriod returned error: %v", err)
+	}
+	if start != time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC) {
+		t.Fatalf("start = %s, want 2026-05-01", start)
+	}
+	if end != time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC) {
+		t.Fatalf("end = %s, want 2026-05-31", end)
+	}
+}
+
+func TestMonthlyBudgetPeriodRejectsInvalidMonth(t *testing.T) {
+	_, _, err := monthlyBudgetPeriod(2026, 13)
+	if appErr, ok := err.(*AppError); !ok || appErr.Code != CodeValidationError {
+		t.Fatalf("err = %v, want validation error", err)
+	}
+}
+
+func TestGetMonthlyBudgetRejectsMissingOwner(t *testing.T) {
+	svc := NewService(&fakeRepo{}, &fakeTransactionService{})
+
+	_, err := svc.GetMonthlyBudget(context.Background(), GetMonthlyBudgetRequest{
+		Year:  2026,
+		Month: 5,
+	})
+
+	if appErr, ok := err.(*AppError); !ok || appErr.Code != CodeValidationError {
+		t.Fatalf("err = %v, want validation error", err)
+	}
+}
+
+func TestGetMonthlyBudgetRejectsMultipleOwners(t *testing.T) {
+	householdID := int64(1)
+	userID := int64(2)
+	svc := NewService(&fakeRepo{}, &fakeTransactionService{})
+
+	_, err := svc.GetMonthlyBudget(context.Background(), GetMonthlyBudgetRequest{
+		HouseholdID: &householdID,
+		UserID:      &userID,
+		Year:        2026,
+		Month:       5,
+	})
+
+	if appErr, ok := err.(*AppError); !ok || appErr.Code != CodeValidationError {
+		t.Fatalf("err = %v, want validation error", err)
+	}
+}
+
+func TestGetMonthlyBudgetReturnsExistingHouseholdBudget(t *testing.T) {
+	householdID := int64(1)
+	repo := &fakeRepo{
+		householdBudgetByPeriod: sqlc.Budget{
+			ID:          12,
+			HouseholdID: &householdID,
+			PeriodStart: pgtype.Date{Time: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC), Valid: true},
+			PeriodEnd:   pgtype.Date{Time: time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC), Valid: true},
+		},
+	}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	budget, err := svc.GetMonthlyBudget(context.Background(), GetMonthlyBudgetRequest{
+		HouseholdID: &householdID,
+		Year:        2026,
+		Month:       5,
+	})
+
+	if err != nil {
+		t.Fatalf("GetMonthlyBudget returned error: %v", err)
+	}
+	if budget.ID != 12 || budget.HouseholdID == nil || *budget.HouseholdID != 1 {
+		t.Fatalf("budget = %+v, want household budget 12", budget)
+	}
+	if !repo.lastGetHouseholdBudgetStart.Equal(time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("period start = %s, want 2026-05-01", repo.lastGetHouseholdBudgetStart)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+go test ./internal/app
+```
+
+Expected: FAIL with undefined names such as `monthlyBudgetPeriod`, `GetMonthlyBudgetRequest`, and `GetMonthlyBudget`.
+
+- [ ] **Step 3: Add budget repository methods to `internal/app/service.go`**
+
+Modify the repository composition:
+
+```go
+type Repository interface {
+	UserRepository
+	HouseholdRepository
+	TransactionRepository
+	CategoryRepository
+	BudgetRepository
+}
+```
+
+Add the interface:
+
+```go
+type BudgetRepository interface {
+	GetHouseholdBudgetByPeriod(context.Context, sqlc.GetHouseholdBudgetByPeriodParams) (sqlc.Budget, error)
+	GetUserBudgetByPeriod(context.Context, sqlc.GetUserBudgetByPeriodParams) (sqlc.Budget, error)
+	GetBudgetById(context.Context, int64) (sqlc.Budget, error)
+	GetLatestPriorHouseholdBudget(context.Context, sqlc.GetLatestPriorHouseholdBudgetParams) (sqlc.Budget, error)
+	GetLatestPriorUserBudget(context.Context, sqlc.GetLatestPriorUserBudgetParams) (sqlc.Budget, error)
+	ListBudgetLines(context.Context, int64) ([]sqlc.BudgetLine, error)
+	ListBudgetLineCategories(context.Context, int64) ([]sqlc.ListBudgetLineCategoriesRow, error)
+	GetBudgetLineById(context.Context, int64) (sqlc.BudgetLine, error)
+	GetMaxBudgetLineSortOrder(context.Context, int64) (int32, error)
+	CreateHouseholdBudget(context.Context, sqlc.CreateHouseholdBudgetParams) (sqlc.Budget, error)
+	CreateUserBudget(context.Context, sqlc.CreateUserBudgetParams) (sqlc.Budget, error)
+	CreateBudgetLine(context.Context, sqlc.CreateBudgetLineParams) (sqlc.BudgetLine, error)
+	UpdateBudgetLine(context.Context, sqlc.UpdateBudgetLineParams) (sqlc.BudgetLine, error)
+	DeleteBudgetLine(context.Context, int64) error
+	DeleteBudgetLineCategories(context.Context, int64) error
+	CreateBudgetLineCategory(context.Context, sqlc.CreateBudgetLineCategoryParams) error
+	ListBudgetTransactions(context.Context, sqlc.ListBudgetTransactionsParams) ([]sqlc.ListBudgetTransactionsRow, error)
+	SumUncategorizedBudgetTransactions(context.Context, sqlc.SumUncategorizedBudgetTransactionsParams) (float32, error)
+}
+```
+
+- [ ] **Step 4: Add budget DTOs and monthly retrieval in `internal/app/budgets.go`**
+
+Create `internal/app/budgets.go`:
+
+```go
+package app
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"rdmm404/voltr-finance/internal/database/sqlc"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type GetMonthlyBudgetRequest struct {
+	HouseholdID     *int64 `json:"householdId,omitempty"`
+	UserID          *int64 `json:"userId,omitempty"`
+	Year            int    `json:"year"`
+	Month           int    `json:"month"`
+	CreateIfMissing bool   `json:"createIfMissing,omitempty"`
+}
+
+type BudgetDTO struct {
+	ID             int64           `json:"id"`
+	HouseholdID    *int64          `json:"householdId,omitempty"`
+	UserID         *int64          `json:"userId,omitempty"`
+	PeriodStart    time.Time       `json:"periodStart"`
+	PeriodEnd      time.Time       `json:"periodEnd"`
+	SourceBudgetID *int64          `json:"sourceBudgetId,omitempty"`
+	Lines          []BudgetLineDTO `json:"lines"`
+}
+
+type BudgetLineDTO struct {
+	ID               int64            `json:"id"`
+	BudgetID         int64            `json:"budgetId"`
+	Name             string           `json:"name"`
+	AllocationAmount string           `json:"allocationAmount"`
+	SortOrder        int32            `json:"sortOrder"`
+	Categories       []CategoryRefDTO `json:"categories"`
+}
+
+func (s *Service) GetMonthlyBudget(ctx context.Context, req GetMonthlyBudgetRequest) (BudgetDTO, error) {
+	if err := validateBudgetOwner(req.HouseholdID, req.UserID); err != nil {
+		return BudgetDTO{}, err
+	}
+	start, end, err := monthlyBudgetPeriod(req.Year, req.Month)
+	if err != nil {
+		return BudgetDTO{}, err
+	}
+
+	budget, err := s.findBudgetByPeriod(ctx, req.HouseholdID, req.UserID, start, end)
+	if err == nil {
+		return s.budgetDTO(ctx, budget)
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return BudgetDTO{}, mapBudgetError(err)
+	}
+	if !req.CreateIfMissing {
+		return BudgetDTO{}, NewError(CodeValidationError, "budget not found", err)
+	}
+
+	created, err := s.createMonthlyBudget(ctx, req.HouseholdID, req.UserID, start, end)
+	if err != nil {
+		return BudgetDTO{}, err
+	}
+	return s.budgetDTO(ctx, created)
+}
+
+func validateBudgetOwner(householdID, userID *int64) error {
+	if householdID == nil && userID == nil {
+		return NewError(CodeValidationError, "exactly one budget owner is required", nil)
+	}
+	if householdID != nil && userID != nil {
+		return NewError(CodeValidationError, "only one budget owner is allowed", nil)
+	}
+	return nil
+}
+
+func monthlyBudgetPeriod(year, month int) (time.Time, time.Time, error) {
+	if year < 1 || month < 1 || month > 12 {
+		return time.Time{}, time.Time{}, NewError(CodeValidationError, "invalid budget month", nil)
+	}
+	start := time.Date(year, time.Month(month), 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 1, -1)
+	return start, end, nil
+}
+
+func (s *Service) findBudgetByPeriod(ctx context.Context, householdID, userID *int64, start, end time.Time) (sqlc.Budget, error) {
+	if householdID != nil {
+		return s.repo.GetHouseholdBudgetByPeriod(ctx, sqlc.GetHouseholdBudgetByPeriodParams{
+			HouseholdID:  householdID,
+			PeriodStart: pgtype.Date{Time: start, Valid: true},
+			PeriodEnd:   pgtype.Date{Time: end, Valid: true},
+		})
+	}
+	return s.repo.GetUserBudgetByPeriod(ctx, sqlc.GetUserBudgetByPeriodParams{
+		UserID:      userID,
+		PeriodStart: pgtype.Date{Time: start, Valid: true},
+		PeriodEnd:   pgtype.Date{Time: end, Valid: true},
+	})
+}
+
+func (s *Service) createMonthlyBudget(ctx context.Context, householdID, userID *int64, start, end time.Time) (sqlc.Budget, error) {
+	if householdID != nil {
+		budget, err := s.repo.CreateHouseholdBudget(ctx, sqlc.CreateHouseholdBudgetParams{
+			HouseholdID:  householdID,
+			PeriodStart: pgtype.Date{Time: start, Valid: true},
+			PeriodEnd:   pgtype.Date{Time: end, Valid: true},
+		})
+		if err != nil {
+			return sqlc.Budget{}, mapBudgetError(err)
+		}
+		return budget, nil
+	}
+	budget, err := s.repo.CreateUserBudget(ctx, sqlc.CreateUserBudgetParams{
+		UserID:      userID,
+		PeriodStart: pgtype.Date{Time: start, Valid: true},
+		PeriodEnd:   pgtype.Date{Time: end, Valid: true},
+	})
+	if err != nil {
+		return sqlc.Budget{}, mapBudgetError(err)
+	}
+	return budget, nil
+}
+
+func (s *Service) budgetDTO(ctx context.Context, budget sqlc.Budget) (BudgetDTO, error) {
+	lines, err := s.repo.ListBudgetLines(ctx, budget.ID)
+	if err != nil {
+		return BudgetDTO{}, mapBudgetError(err)
+	}
+	categories, err := s.repo.ListBudgetLineCategories(ctx, budget.ID)
+	if err != nil {
+		return BudgetDTO{}, mapBudgetError(err)
+	}
+	categoriesByLine := make(map[int64][]CategoryRefDTO)
+	for _, row := range categories {
+		categoriesByLine[row.BudgetLineID] = append(categoriesByLine[row.BudgetLineID], CategoryRefDTO{
+			ID:   row.CategoryID,
+			Code: row.CategoryCode,
+			Name: row.CategoryName,
+		})
+	}
+	dtoLines := make([]BudgetLineDTO, 0, len(lines))
+	for _, line := range lines {
+		dtoLines = append(dtoLines, budgetLineDTO(line, categoriesByLine[line.ID]))
+	}
+	return BudgetDTO{
+		ID:             budget.ID,
+		HouseholdID:    budget.HouseholdID,
+		UserID:         budget.UserID,
+		PeriodStart:    budget.PeriodStart.Time,
+		PeriodEnd:      budget.PeriodEnd.Time,
+		SourceBudgetID: budget.SourceBudgetID,
+		Lines:          dtoLines,
+	}, nil
+}
+
+func budgetLineDTO(line sqlc.BudgetLine, categories []CategoryRefDTO) BudgetLineDTO {
+	return BudgetLineDTO{
+		ID:               line.ID,
+		BudgetID:         line.BudgetID,
+		Name:             line.Name,
+		AllocationAmount: line.AllocationAmount,
+		SortOrder:        line.SortOrder,
+		Categories:       categories,
+	}
+}
+
+func mapBudgetError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return NewError(CodeValidationError, "budget not found", err)
+	}
+	return NewError(CodeDatabaseError, "database error", err)
+}
+```
+
+Keep `AllocationAmount` as a JSON string in app DTOs and requests. `allocation_amount NUMERIC(12, 2)` should be converted at the app boundary with focused helpers in `internal/app/budgets.go`:
+
+```go
+func parseBudgetNumeric(value string) (pgtype.Numeric, error) {
+	value = strings.TrimSpace(value)
+	rat, ok := new(big.Rat).SetString(value)
+	if !ok {
+		return pgtype.Numeric{}, NewError(CodeValidationError, "allocation amount must be a decimal number", nil)
+	}
+	scaled := new(big.Rat).Mul(rat, big.NewRat(100, 1))
+	if !scaled.IsInt() {
+		return pgtype.Numeric{}, NewError(CodeValidationError, "allocation amount must have at most two decimal places", nil)
+	}
+	return pgtype.Numeric{Int: scaled.Num(), Exp: -2, Valid: true}, nil
+}
+
+func budgetNumericString(value pgtype.Numeric) string {
+	if !value.Valid || value.Int == nil {
+		return "0.00"
+	}
+	rat := new(big.Rat).SetInt(value.Int)
+	if value.Exp < 0 {
+		rat.Quo(rat, new(big.Rat).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(-value.Exp)), nil)))
+	}
+	if value.Exp > 0 {
+		rat.Mul(rat, new(big.Rat).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(value.Exp)), nil)))
+	}
+	out, _ := rat.Float64()
+	return fmt.Sprintf("%.2f", out)
+}
+```
+
+Add `math/big` to the import block when these helpers are needed. Use `parseBudgetNumeric` when setting sqlc params and `budgetNumericString` when building DTOs.
+
+- [ ] **Step 5: Add fake repository budget fields and methods**
+
+In `internal/app/test_fakes_test.go`, add fields to `fakeRepo`:
+
+```go
+householdBudgetByPeriod sqlc.Budget
+userBudgetByPeriod      sqlc.Budget
+budgetByID              sqlc.Budget
+latestHouseholdBudget   sqlc.Budget
+latestUserBudget        sqlc.Budget
+createdHouseholdBudget  sqlc.Budget
+createdUserBudget       sqlc.Budget
+budgetLines             []sqlc.BudgetLine
+budgetLineCategories    []sqlc.ListBudgetLineCategoriesRow
+
+lastGetHouseholdBudgetStart time.Time
+lastGetUserBudgetStart      time.Time
+lastCreateHouseholdBudget   sqlc.CreateHouseholdBudgetParams
+lastCreateUserBudget        sqlc.CreateUserBudgetParams
+```
+
+Add `time` to the test fake imports.
+
+Add methods:
+
+```go
+func (f *fakeRepo) GetHouseholdBudgetByPeriod(_ context.Context, arg sqlc.GetHouseholdBudgetByPeriodParams) (sqlc.Budget, error) {
+	f.lastGetHouseholdBudgetStart = arg.PeriodStart.Time
+	if f.householdBudgetByPeriod.ID == 0 {
+		return sqlc.Budget{}, sql.ErrNoRows
+	}
+	return f.householdBudgetByPeriod, nil
+}
+
+func (f *fakeRepo) GetUserBudgetByPeriod(_ context.Context, arg sqlc.GetUserBudgetByPeriodParams) (sqlc.Budget, error) {
+	f.lastGetUserBudgetStart = arg.PeriodStart.Time
+	if f.userBudgetByPeriod.ID == 0 {
+		return sqlc.Budget{}, sql.ErrNoRows
+	}
+	return f.userBudgetByPeriod, nil
+}
+
+func (f *fakeRepo) GetBudgetById(context.Context, int64) (sqlc.Budget, error) {
+	if f.budgetByID.ID == 0 {
+		return sqlc.Budget{}, sql.ErrNoRows
+	}
+	return f.budgetByID, nil
+}
+
+func (f *fakeRepo) GetLatestPriorHouseholdBudget(context.Context, sqlc.GetLatestPriorHouseholdBudgetParams) (sqlc.Budget, error) {
+	if f.latestHouseholdBudget.ID == 0 {
+		return sqlc.Budget{}, sql.ErrNoRows
+	}
+	return f.latestHouseholdBudget, nil
+}
+
+func (f *fakeRepo) GetLatestPriorUserBudget(context.Context, sqlc.GetLatestPriorUserBudgetParams) (sqlc.Budget, error) {
+	if f.latestUserBudget.ID == 0 {
+		return sqlc.Budget{}, sql.ErrNoRows
+	}
+	return f.latestUserBudget, nil
+}
+
+func (f *fakeRepo) ListBudgetLines(context.Context, int64) ([]sqlc.BudgetLine, error) {
+	return f.budgetLines, nil
+}
+
+func (f *fakeRepo) ListBudgetLineCategories(context.Context, int64) ([]sqlc.ListBudgetLineCategoriesRow, error) {
+	return f.budgetLineCategories, nil
+}
+
+func (f *fakeRepo) CreateHouseholdBudget(_ context.Context, arg sqlc.CreateHouseholdBudgetParams) (sqlc.Budget, error) {
+	f.lastCreateHouseholdBudget = arg
+	if f.createdHouseholdBudget.ID != 0 {
+		return f.createdHouseholdBudget, nil
+	}
+	return sqlc.Budget{ID: 1, HouseholdID: arg.HouseholdID, PeriodStart: arg.PeriodStart, PeriodEnd: arg.PeriodEnd, SourceBudgetID: arg.SourceBudgetID}, nil
+}
+
+func (f *fakeRepo) CreateUserBudget(_ context.Context, arg sqlc.CreateUserBudgetParams) (sqlc.Budget, error) {
+	f.lastCreateUserBudget = arg
+	if f.createdUserBudget.ID != 0 {
+		return f.createdUserBudget, nil
+	}
+	return sqlc.Budget{ID: 1, UserID: arg.UserID, PeriodStart: arg.PeriodStart, PeriodEnd: arg.PeriodEnd, SourceBudgetID: arg.SourceBudgetID}, nil
+}
+```
+
+Add stub methods for budget line/report repository calls that are used in later tasks:
+
+```go
+func (f *fakeRepo) GetBudgetLineById(context.Context, int64) (sqlc.BudgetLine, error) {
+	return sqlc.BudgetLine{}, sql.ErrNoRows
+}
+
+func (f *fakeRepo) GetMaxBudgetLineSortOrder(context.Context, int64) (int32, error) {
+	return 0, nil
+}
+
+func (f *fakeRepo) CreateBudgetLine(context.Context, sqlc.CreateBudgetLineParams) (sqlc.BudgetLine, error) {
+	return sqlc.BudgetLine{}, nil
+}
+
+func (f *fakeRepo) UpdateBudgetLine(context.Context, sqlc.UpdateBudgetLineParams) (sqlc.BudgetLine, error) {
+	return sqlc.BudgetLine{}, nil
+}
+
+func (f *fakeRepo) DeleteBudgetLine(context.Context, int64) error {
+	return nil
+}
+
+func (f *fakeRepo) DeleteBudgetLineCategories(context.Context, int64) error {
+	return nil
+}
+
+func (f *fakeRepo) CreateBudgetLineCategory(context.Context, sqlc.CreateBudgetLineCategoryParams) error {
+	return nil
+}
+
+func (f *fakeRepo) ListBudgetTransactions(context.Context, sqlc.ListBudgetTransactionsParams) ([]sqlc.ListBudgetTransactionsRow, error) {
+	return nil, nil
+}
+
+func (f *fakeRepo) SumUncategorizedBudgetTransactions(context.Context, sqlc.SumUncategorizedBudgetTransactionsParams) (float32, error) {
+	return 0, nil
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run:
+
+```bash
+go test ./internal/app
+```
+
+Expected: PASS for the new monthly period and existing budget tests.
+
+- [ ] **Step 7: Commit app budget retrieval**
+
+Run:
+
+```bash
+git add internal/app/service.go internal/app/budgets.go internal/app/budgets_test.go internal/app/test_fakes_test.go
+git commit -m "Add monthly budget retrieval service"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 3: Auto-Copy Latest Prior Budget
+
+**Files:**
+- Modify: `internal/app/budgets.go`
+- Modify: `internal/app/budgets_test.go`
+- Modify: `internal/app/test_fakes_test.go`
+
+- [ ] **Step 1: Add failing test for empty budget creation**
+
+Append to `internal/app/budgets_test.go`:
+
+```go
+func TestGetMonthlyBudgetCreatesEmptyBudgetWithoutPriorBudget(t *testing.T) {
+	householdID := int64(1)
+	repo := &fakeRepo{}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	budget, err := svc.GetMonthlyBudget(context.Background(), GetMonthlyBudgetRequest{
+		HouseholdID:     &householdID,
+		Year:            2026,
+		Month:           5,
+		CreateIfMissing: true,
+	})
+
+	if err != nil {
+		t.Fatalf("GetMonthlyBudget returned error: %v", err)
+	}
+	if budget.ID != 1 || budget.HouseholdID == nil || *budget.HouseholdID != 1 {
+		t.Fatalf("budget = %+v, want created household budget", budget)
+	}
+	if repo.lastCreateHouseholdBudget.SourceBudgetID != nil {
+		t.Fatalf("SourceBudgetID = %v, want nil", repo.lastCreateHouseholdBudget.SourceBudgetID)
+	}
+}
+```
+
+- [ ] **Step 2: Add failing test for copying prior budget lines and category mappings**
+
+Append:
+
+```go
+func TestGetMonthlyBudgetCopiesLatestPriorBudget(t *testing.T) {
+	householdID := int64(1)
+	sourceID := int64(7)
+	repo := &fakeRepo{
+		latestHouseholdBudget: sqlc.Budget{ID: sourceID, HouseholdID: &householdID},
+		createdHouseholdBudget: sqlc.Budget{
+			ID:             12,
+			HouseholdID:    &householdID,
+			SourceBudgetID: &sourceID,
+			PeriodStart:    pgtype.Date{Time: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), Valid: true},
+			PeriodEnd:      pgtype.Date{Time: time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC), Valid: true},
+		},
+		budgetLines: []sqlc.BudgetLine{
+			{ID: 101, BudgetID: sourceID, Name: "Groceries", AllocationAmount: "800.00", SortOrder: 1},
+			{ID: 102, BudgetID: sourceID, Name: "Savings", AllocationAmount: "500.00", SortOrder: 2},
+		},
+		budgetLineCategories: []sqlc.ListBudgetLineCategoriesRow{
+			{BudgetID: sourceID, BudgetLineID: 101, CategoryID: 3, CategoryCode: "groceries", CategoryName: "Groceries"},
+		},
+	}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	budget, err := svc.GetMonthlyBudget(context.Background(), GetMonthlyBudgetRequest{
+		HouseholdID:     &householdID,
+		Year:            2026,
+		Month:           7,
+		CreateIfMissing: true,
+	})
+
+	if err != nil {
+		t.Fatalf("GetMonthlyBudget returned error: %v", err)
+	}
+	if budget.SourceBudgetID == nil || *budget.SourceBudgetID != sourceID {
+		t.Fatalf("SourceBudgetID = %v, want 7", budget.SourceBudgetID)
+	}
+	if len(repo.createdBudgetLines) != 2 {
+		t.Fatalf("createdBudgetLines = %d, want 2", len(repo.createdBudgetLines))
+	}
+	if repo.createdBudgetLines[0].Name != "Groceries" || repo.createdBudgetLines[0].BudgetID != 12 {
+		t.Fatalf("first copied line = %+v, want Groceries on budget 12", repo.createdBudgetLines[0])
+	}
+	if len(repo.createdBudgetLineCategories) != 1 || repo.createdBudgetLineCategories[0].CategoryID != 3 {
+		t.Fatalf("created mappings = %+v, want category 3 mapping", repo.createdBudgetLineCategories)
+	}
+}
+```
+
+- [ ] **Step 3: Run tests and verify they fail**
+
+Run:
+
+```bash
+go test ./internal/app
+```
+
+Expected: FAIL because the service does not copy prior budget lines yet and `fakeRepo` lacks tracking fields.
+
+- [ ] **Step 4: Track created lines and mappings in the fake repo**
+
+In `internal/app/test_fakes_test.go`, add fields:
+
+```go
+createdBudgetLines          []sqlc.CreateBudgetLineParams
+createdBudgetLineRows      []sqlc.BudgetLine
+createdBudgetLineCategories []sqlc.CreateBudgetLineCategoryParams
+```
+
+Replace the stub `CreateBudgetLine` and `CreateBudgetLineCategory` methods:
+
+```go
+func (f *fakeRepo) CreateBudgetLine(_ context.Context, arg sqlc.CreateBudgetLineParams) (sqlc.BudgetLine, error) {
+	f.createdBudgetLines = append(f.createdBudgetLines, arg)
+	id := int64(len(f.createdBudgetLines))
+	if len(f.createdBudgetLineRows) >= len(f.createdBudgetLines) {
+		return f.createdBudgetLineRows[len(f.createdBudgetLines)-1], nil
+	}
+	return sqlc.BudgetLine{
+		ID:               id,
+		BudgetID:         arg.BudgetID,
+		Name:             arg.Name,
+		AllocationAmount: arg.AllocationAmount,
+		SortOrder:        arg.SortOrder,
+	}, nil
+}
+
+func (f *fakeRepo) CreateBudgetLineCategory(_ context.Context, arg sqlc.CreateBudgetLineCategoryParams) error {
+	f.createdBudgetLineCategories = append(f.createdBudgetLineCategories, arg)
+	return nil
+}
+```
+
+- [ ] **Step 5: Implement prior lookup and copy behavior**
+
+In `internal/app/budgets.go`, update `createMonthlyBudget` so it finds a prior budget and passes `SourceBudgetID` into the create query:
+
+```go
+func (s *Service) createMonthlyBudget(ctx context.Context, householdID, userID *int64, start, end time.Time) (sqlc.Budget, error) {
+	source, sourceID, err := s.latestPriorBudget(ctx, householdID, userID, start)
+	if err != nil {
+		return sqlc.Budget{}, err
+	}
+
+	var budget sqlc.Budget
+	if householdID != nil {
+		budget, err = s.repo.CreateHouseholdBudget(ctx, sqlc.CreateHouseholdBudgetParams{
+			HouseholdID:     householdID,
+			PeriodStart:    pgtype.Date{Time: start, Valid: true},
+			PeriodEnd:      pgtype.Date{Time: end, Valid: true},
+			SourceBudgetID: sourceID,
+		})
+	} else {
+		budget, err = s.repo.CreateUserBudget(ctx, sqlc.CreateUserBudgetParams{
+			UserID:         userID,
+			PeriodStart:    pgtype.Date{Time: start, Valid: true},
+			PeriodEnd:      pgtype.Date{Time: end, Valid: true},
+			SourceBudgetID: sourceID,
+		})
+	}
+	if err != nil {
+		return sqlc.Budget{}, mapBudgetError(err)
+	}
+	if source.ID != 0 {
+		if err := s.copyBudgetLines(ctx, source.ID, budget.ID); err != nil {
+			return sqlc.Budget{}, err
+		}
+	}
+	return budget, nil
+}
+
+func (s *Service) latestPriorBudget(ctx context.Context, householdID, userID *int64, start time.Time) (sqlc.Budget, *int64, error) {
+	var budget sqlc.Budget
+	var err error
+	if householdID != nil {
+		budget, err = s.repo.GetLatestPriorHouseholdBudget(ctx, sqlc.GetLatestPriorHouseholdBudgetParams{
+			HouseholdID:  householdID,
+			PeriodStart: pgtype.Date{Time: start, Valid: true},
+		})
+	} else {
+		budget, err = s.repo.GetLatestPriorUserBudget(ctx, sqlc.GetLatestPriorUserBudgetParams{
+			UserID:      userID,
+			PeriodStart: pgtype.Date{Time: start, Valid: true},
+		})
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return sqlc.Budget{}, nil, nil
+	}
+	if err != nil {
+		return sqlc.Budget{}, nil, mapBudgetError(err)
+	}
+	return budget, &budget.ID, nil
+}
+```
+
+Add copy helper:
+
+```go
+func (s *Service) copyBudgetLines(ctx context.Context, sourceBudgetID, targetBudgetID int64) error {
+	lines, err := s.repo.ListBudgetLines(ctx, sourceBudgetID)
+	if err != nil {
+		return mapBudgetError(err)
+	}
+	mappings, err := s.repo.ListBudgetLineCategories(ctx, sourceBudgetID)
+	if err != nil {
+		return mapBudgetError(err)
+	}
+	mappingsByLine := make(map[int64][]sqlc.ListBudgetLineCategoriesRow)
+	for _, mapping := range mappings {
+		mappingsByLine[mapping.BudgetLineID] = append(mappingsByLine[mapping.BudgetLineID], mapping)
+	}
+	for _, sourceLine := range lines {
+		targetLine, err := s.repo.CreateBudgetLine(ctx, sqlc.CreateBudgetLineParams{
+			BudgetID:         targetBudgetID,
+			Name:             sourceLine.Name,
+			AllocationAmount: sourceLine.AllocationAmount,
+			SortOrder:        sourceLine.SortOrder,
+		})
+		if err != nil {
+			return mapBudgetError(err)
+		}
+		for _, mapping := range mappingsByLine[sourceLine.ID] {
+			if err := s.repo.CreateBudgetLineCategory(ctx, sqlc.CreateBudgetLineCategoryParams{
+				BudgetID:     targetBudgetID,
+				BudgetLineID: targetLine.ID,
+				CategoryID:   mapping.CategoryID,
+			}); err != nil {
+				return mapBudgetError(err)
+			}
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run:
+
+```bash
+go test ./internal/app
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit auto-copy behavior**
+
+Run:
+
+```bash
+git add internal/app/budgets.go internal/app/budgets_test.go internal/app/test_fakes_test.go
+git commit -m "Add monthly budget auto-copy"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 4: Budget Line Create, Update, and Delete Services
+
+**Files:**
+- Modify: `internal/app/budgets.go`
+- Modify: `internal/app/budgets_test.go`
+- Modify: `internal/app/test_fakes_test.go`
+
+- [ ] **Step 1: Add failing tests for line creation and category validation**
+
+Append to `internal/app/budgets_test.go`:
+
+```go
+func TestCreateBudgetLineResolvesCategoryCodes(t *testing.T) {
+	repo := &fakeRepo{
+		budgetByID:      sqlc.Budget{ID: 12},
+		categoryByCode:  sqlc.Category{ID: 3, Code: "groceries", Name: "Groceries", IsActive: true},
+		maxSortOrder:    2,
+		createdBudgetLineRows: []sqlc.BudgetLine{
+			{ID: 44, BudgetID: 12, Name: "Groceries", AllocationAmount: "800.00", SortOrder: 3},
+		},
+	}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	line, err := svc.CreateBudgetLine(context.Background(), CreateBudgetLineRequest{
+		BudgetID:          12,
+		Name:              "Groceries",
+		AllocationAmount:  "800.00",
+		CategoryCodes:     []string{"groceries"},
+	})
+
+	if err != nil {
+		t.Fatalf("CreateBudgetLine returned error: %v", err)
+	}
+	if line.ID != 44 || line.SortOrder != 3 {
+		t.Fatalf("line = %+v, want id 44 sort order 3", line)
+	}
+	if len(repo.createdBudgetLineCategories) != 1 || repo.createdBudgetLineCategories[0].CategoryID != 3 {
+		t.Fatalf("created mappings = %+v, want category 3", repo.createdBudgetLineCategories)
+	}
+}
+
+func TestCreateBudgetLineRejectsReusedCategory(t *testing.T) {
+	repo := &fakeRepo{
+		budgetByID:     sqlc.Budget{ID: 12},
+		categoryByCode: sqlc.Category{ID: 3, Code: "groceries", Name: "Groceries", IsActive: true},
+		budgetLineCategories: []sqlc.ListBudgetLineCategoriesRow{
+			{BudgetID: 12, BudgetLineID: 40, CategoryID: 3, CategoryCode: "groceries", CategoryName: "Groceries"},
+		},
+	}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	_, err := svc.CreateBudgetLine(context.Background(), CreateBudgetLineRequest{
+		BudgetID:         12,
+		Name:             "Food",
+		AllocationAmount: "800.00",
+		CategoryCodes:    []string{"groceries"},
+	})
+
+	if appErr, ok := err.(*AppError); !ok || appErr.Code != CodeValidationError {
+		t.Fatalf("err = %v, want validation error", err)
+	}
+}
+```
+
+- [ ] **Step 2: Add failing tests for line update and delete**
+
+Append:
+
+```go
+func TestUpdateBudgetLineReplacesOnlyThatLineCategories(t *testing.T) {
+	repo := &fakeRepo{
+		budgetLineByID: sqlc.BudgetLine{ID: 44, BudgetID: 12, Name: "Groceries", AllocationAmount: "800.00", SortOrder: 1},
+		categoryByCode: sqlc.Category{ID: 3, Code: "groceries", Name: "Groceries", IsActive: true},
+		updatedBudgetLine: sqlc.BudgetLine{ID: 44, BudgetID: 12, Name: "Groceries", AllocationAmount: "900.00", SortOrder: 1},
+	}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	line, err := svc.UpdateBudgetLine(context.Background(), UpdateBudgetLineRequest{
+		LineID:           44,
+		AllocationAmount: strPtr("900.00"),
+		CategoryCodes:    &[]string{"groceries"},
+	})
+
+	if err != nil {
+		t.Fatalf("UpdateBudgetLine returned error: %v", err)
+	}
+	if line.AllocationAmount != "900.00" {
+		t.Fatalf("AllocationAmount = %q, want 900.00", line.AllocationAmount)
+	}
+	if repo.deletedBudgetLineCategoryID != 44 {
+		t.Fatalf("deletedBudgetLineCategoryID = %d, want 44", repo.deletedBudgetLineCategoryID)
+	}
+	if len(repo.createdBudgetLineCategories) != 1 || repo.createdBudgetLineCategories[0].BudgetLineID != 44 {
+		t.Fatalf("created mappings = %+v, want mapping for line 44", repo.createdBudgetLineCategories)
+	}
+}
+
+func TestDeleteBudgetLineDeletesLine(t *testing.T) {
+	repo := &fakeRepo{}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	err := svc.DeleteBudgetLine(context.Background(), 44)
+
+	if err != nil {
+		t.Fatalf("DeleteBudgetLine returned error: %v", err)
+	}
+	if repo.deletedBudgetLineID != 44 {
+		t.Fatalf("deletedBudgetLineID = %d, want 44", repo.deletedBudgetLineID)
+	}
+}
+```
+
+- [ ] **Step 3: Run tests and verify they fail**
+
+Run:
+
+```bash
+go test ./internal/app
+```
+
+Expected: FAIL with undefined request types and service methods.
+
+- [ ] **Step 4: Add request types and service methods**
+
+In `internal/app/budgets.go`, add request types:
+
+```go
+type CreateBudgetLineRequest struct {
+	BudgetID         int64    `json:"budgetId"`
+	Name             string   `json:"name"`
+	AllocationAmount string   `json:"allocationAmount"`
+	CategoryIDs      []int64  `json:"categoryIds,omitempty"`
+	CategoryCodes    []string `json:"categoryCodes,omitempty"`
+	SortOrder        *int32   `json:"sortOrder,omitempty"`
+}
+
+type UpdateBudgetLineRequest struct {
+	LineID           int64     `json:"lineId"`
+	Name             *string   `json:"name,omitempty"`
+	AllocationAmount *string   `json:"allocationAmount,omitempty"`
+	CategoryIDs      *[]int64  `json:"categoryIds,omitempty"`
+	CategoryCodes    *[]string `json:"categoryCodes,omitempty"`
+	SortOrder        *int32    `json:"sortOrder,omitempty"`
+}
+```
+
+Add methods:
+
+```go
+func (s *Service) CreateBudgetLine(ctx context.Context, req CreateBudgetLineRequest) (BudgetLineDTO, error) {
+	if req.BudgetID == 0 {
+		return BudgetLineDTO{}, NewError(CodeValidationError, "budget id is required", nil)
+	}
+	if _, err := s.repo.GetBudgetById(ctx, req.BudgetID); err != nil {
+		return BudgetLineDTO{}, mapBudgetError(err)
+	}
+	name, err := validateBudgetLineName(req.Name)
+	if err != nil {
+		return BudgetLineDTO{}, err
+	}
+	if err := validateBudgetAmount(req.AllocationAmount); err != nil {
+		return BudgetLineDTO{}, err
+	}
+	categoryIDs, err := s.resolveBudgetCategoryIDs(ctx, req.CategoryIDs, req.CategoryCodes)
+	if err != nil {
+		return BudgetLineDTO{}, err
+	}
+	if err := s.validateBudgetCategoryAvailability(ctx, req.BudgetID, 0, categoryIDs); err != nil {
+		return BudgetLineDTO{}, err
+	}
+	sortOrder := req.SortOrder
+	if sortOrder == nil {
+		max, err := s.repo.GetMaxBudgetLineSortOrder(ctx, req.BudgetID)
+		if err != nil {
+			return BudgetLineDTO{}, mapBudgetError(err)
+		}
+		next := max + 1
+		sortOrder = &next
+	}
+	line, err := s.repo.CreateBudgetLine(ctx, sqlc.CreateBudgetLineParams{
+		BudgetID:          req.BudgetID,
+		Name:              name,
+		AllocationAmount:  req.AllocationAmount,
+		SortOrder:         *sortOrder,
+	})
+	if err != nil {
+		return BudgetLineDTO{}, mapBudgetError(err)
+	}
+	if err := s.replaceBudgetLineCategories(ctx, req.BudgetID, line.ID, categoryIDs); err != nil {
+		return BudgetLineDTO{}, err
+	}
+	return s.budgetLineDTOWithCategories(ctx, line)
+}
+
+func (s *Service) UpdateBudgetLine(ctx context.Context, req UpdateBudgetLineRequest) (BudgetLineDTO, error) {
+	if req.LineID == 0 {
+		return BudgetLineDTO{}, NewError(CodeValidationError, "budget line id is required", nil)
+	}
+	existing, err := s.repo.GetBudgetLineById(ctx, req.LineID)
+	if err != nil {
+		return BudgetLineDTO{}, mapBudgetError(err)
+	}
+	params := sqlc.UpdateBudgetLineParams{ID: req.LineID}
+	if req.Name != nil {
+		name, err := validateBudgetLineName(*req.Name)
+		if err != nil {
+			return BudgetLineDTO{}, err
+		}
+		params.SetName = true
+		params.Name = name
+	}
+	if req.AllocationAmount != nil {
+		if err := validateBudgetAmount(*req.AllocationAmount); err != nil {
+			return BudgetLineDTO{}, err
+		}
+		params.SetAllocationAmount = true
+		params.AllocationAmount = *req.AllocationAmount
+	}
+	if req.SortOrder != nil {
+		params.SetSortOrder = true
+		params.SortOrder = *req.SortOrder
+	}
+	line, err := s.repo.UpdateBudgetLine(ctx, params)
+	if err != nil {
+		return BudgetLineDTO{}, mapBudgetError(err)
+	}
+	if req.CategoryIDs != nil || req.CategoryCodes != nil {
+		ids := []int64(nil)
+		codes := []string(nil)
+		if req.CategoryIDs != nil {
+			ids = *req.CategoryIDs
+		}
+		if req.CategoryCodes != nil {
+			codes = *req.CategoryCodes
+		}
+		categoryIDs, err := s.resolveBudgetCategoryIDs(ctx, ids, codes)
+		if err != nil {
+			return BudgetLineDTO{}, err
+		}
+		if err := s.validateBudgetCategoryAvailability(ctx, existing.BudgetID, existing.ID, categoryIDs); err != nil {
+			return BudgetLineDTO{}, err
+		}
+		if err := s.replaceBudgetLineCategories(ctx, existing.BudgetID, existing.ID, categoryIDs); err != nil {
+			return BudgetLineDTO{}, err
+		}
+	}
+	return s.budgetLineDTOWithCategories(ctx, line)
+}
+
+func (s *Service) DeleteBudgetLine(ctx context.Context, lineID int64) error {
+	if lineID == 0 {
+		return NewError(CodeValidationError, "budget line id is required", nil)
+	}
+	if err := s.repo.DeleteBudgetLine(ctx, lineID); err != nil {
+		return mapBudgetError(err)
+	}
+	return nil
+}
+```
+
+Add helpers:
+
+```go
+func validateBudgetLineName(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", NewError(CodeValidationError, "budget line name is required", nil)
+	}
+	return name, nil
+}
+
+func validateBudgetAmount(amount string) error {
+	amount = strings.TrimSpace(amount)
+	if amount == "" {
+		return NewError(CodeValidationError, "allocation amount is required", nil)
+	}
+	value, err := strconv.ParseFloat(amount, 64)
+	if err != nil || value < 0 {
+		return NewError(CodeValidationError, "allocation amount must be greater than or equal to zero", err)
+	}
+	return nil
+}
+```
+
+Add imports:
+
+```go
+import (
+	"strconv"
+	"strings"
+)
+```
+
+Merge these into the existing import block rather than creating a second one.
+
+- [ ] **Step 5: Add category mapping helpers**
+
+In `internal/app/budgets.go`, add:
+
+```go
+func (s *Service) resolveBudgetCategoryIDs(ctx context.Context, ids []int64, codes []string) ([]int64, error) {
+	seen := make(map[int64]struct{})
+	resolved := make([]int64, 0, len(ids)+len(codes))
+	for _, id := range ids {
+		category, err := s.repo.GetActiveCategoryById(ctx, id)
+		if err != nil {
+			return nil, mapCategoryError(err)
+		}
+		if _, ok := seen[category.ID]; !ok {
+			seen[category.ID] = struct{}{}
+			resolved = append(resolved, category.ID)
+		}
+	}
+	for _, code := range codes {
+		category, err := s.repo.GetActiveCategoryByCode(ctx, code)
+		if err != nil {
+			return nil, mapCategoryError(err)
+		}
+		if _, ok := seen[category.ID]; !ok {
+			seen[category.ID] = struct{}{}
+			resolved = append(resolved, category.ID)
+		}
+	}
+	return resolved, nil
+}
+
+func (s *Service) validateBudgetCategoryAvailability(ctx context.Context, budgetID, currentLineID int64, categoryIDs []int64) error {
+	existing, err := s.repo.ListBudgetLineCategories(ctx, budgetID)
+	if err != nil {
+		return mapBudgetError(err)
+	}
+	wanted := make(map[int64]struct{}, len(categoryIDs))
+	for _, id := range categoryIDs {
+		wanted[id] = struct{}{}
+	}
+	for _, mapping := range existing {
+		if mapping.BudgetLineID == currentLineID {
+			continue
+		}
+		if _, ok := wanted[mapping.CategoryID]; ok {
+			return NewError(CodeValidationError, "category already mapped to another budget line", nil)
+		}
+	}
+	return nil
+}
+
+func (s *Service) replaceBudgetLineCategories(ctx context.Context, budgetID, lineID int64, categoryIDs []int64) error {
+	if err := s.repo.DeleteBudgetLineCategories(ctx, lineID); err != nil {
+		return mapBudgetError(err)
+	}
+	for _, categoryID := range categoryIDs {
+		if err := s.repo.CreateBudgetLineCategory(ctx, sqlc.CreateBudgetLineCategoryParams{
+			BudgetID:     budgetID,
+			BudgetLineID: lineID,
+			CategoryID:   categoryID,
+		}); err != nil {
+			return mapBudgetError(err)
+		}
+	}
+	return nil
+}
+
+func (s *Service) budgetLineDTOWithCategories(ctx context.Context, line sqlc.BudgetLine) (BudgetLineDTO, error) {
+	categories, err := s.repo.ListBudgetLineCategories(ctx, line.BudgetID)
+	if err != nil {
+		return BudgetLineDTO{}, mapBudgetError(err)
+	}
+	lineCategories := []CategoryRefDTO{}
+	for _, row := range categories {
+		if row.BudgetLineID == line.ID {
+			lineCategories = append(lineCategories, CategoryRefDTO{ID: row.CategoryID, Code: row.CategoryCode, Name: row.CategoryName})
+		}
+	}
+	return budgetLineDTO(line, lineCategories), nil
+}
+```
+
+- [ ] **Step 6: Update fake repo for line operations**
+
+In `internal/app/test_fakes_test.go`, add fields:
+
+```go
+budgetLineByID              sqlc.BudgetLine
+updatedBudgetLine           sqlc.BudgetLine
+lastUpdateBudgetLine        sqlc.UpdateBudgetLineParams
+maxSortOrder                int32
+deletedBudgetLineID         int64
+deletedBudgetLineCategoryID int64
+```
+
+Replace stubs:
+
+```go
+func (f *fakeRepo) GetBudgetLineById(context.Context, int64) (sqlc.BudgetLine, error) {
+	if f.budgetLineByID.ID == 0 {
+		return sqlc.BudgetLine{}, sql.ErrNoRows
+	}
+	return f.budgetLineByID, nil
+}
+
+func (f *fakeRepo) GetMaxBudgetLineSortOrder(context.Context, int64) (int32, error) {
+	return f.maxSortOrder, nil
+}
+
+func (f *fakeRepo) UpdateBudgetLine(_ context.Context, arg sqlc.UpdateBudgetLineParams) (sqlc.BudgetLine, error) {
+	f.lastUpdateBudgetLine = arg
+	if f.updatedBudgetLine.ID != 0 {
+		return f.updatedBudgetLine, nil
+	}
+	line := f.budgetLineByID
+	if arg.SetName {
+		line.Name = arg.Name
+	}
+	if arg.SetAllocationAmount {
+		line.AllocationAmount = arg.AllocationAmount
+	}
+	if arg.SetSortOrder {
+		line.SortOrder = arg.SortOrder
+	}
+	return line, nil
+}
+
+func (f *fakeRepo) DeleteBudgetLine(_ context.Context, id int64) error {
+	f.deletedBudgetLineID = id
+	return nil
+}
+
+func (f *fakeRepo) DeleteBudgetLineCategories(_ context.Context, id int64) error {
+	f.deletedBudgetLineCategoryID = id
+	return nil
+}
+```
+
+- [ ] **Step 7: Run tests**
+
+Run:
+
+```bash
+go test ./internal/app
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit line service operations**
+
+Run:
+
+```bash
+git add internal/app/budgets.go internal/app/budgets_test.go internal/app/test_fakes_test.go
+git commit -m "Add budget line service operations"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 5: Budget Report Service
+
+**Files:**
+- Modify: `internal/app/budgets.go`
+- Modify: `internal/app/budgets_test.go`
+- Modify: `internal/app/test_fakes_test.go`
+
+- [ ] **Step 1: Add failing report test**
+
+Append to `internal/app/budgets_test.go`:
+
+```go
+func TestGetBudgetReportDerivesActualsFromCategories(t *testing.T) {
+	householdID := int64(1)
+	repo := &fakeRepo{
+		budgetByID: sqlc.Budget{
+			ID:          12,
+			HouseholdID: &householdID,
+			PeriodStart: pgtype.Date{Time: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC), Valid: true},
+			PeriodEnd:   pgtype.Date{Time: time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC), Valid: true},
+		},
+		budgetLines: []sqlc.BudgetLine{
+			{ID: 44, BudgetID: 12, Name: "Groceries", AllocationAmount: "800.00", SortOrder: 1},
+			{ID: 45, BudgetID: 12, Name: "Savings", AllocationAmount: "500.00", SortOrder: 2},
+		},
+		budgetLineCategories: []sqlc.ListBudgetLineCategoriesRow{
+			{BudgetID: 12, BudgetLineID: 44, CategoryID: 3, CategoryCode: "groceries", CategoryName: "Groceries"},
+		},
+		budgetTransactions: []sqlc.ListBudgetTransactionsRow{
+			{CategoryID: int64Ptr(3), ActualAmount: 570.25},
+		},
+		uncategorizedBudgetTransactions: 123.45,
+	}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	report, err := svc.GetBudgetReport(context.Background(), 12)
+
+	if err != nil {
+		t.Fatalf("GetBudgetReport returned error: %v", err)
+	}
+	if len(report.Lines) != 2 {
+		t.Fatalf("lines = %d, want 2", len(report.Lines))
+	}
+	if report.Lines[0].ActualAmount != "570.25" || report.Lines[0].RemainingAmount != "229.75" {
+		t.Fatalf("groceries line = %+v, want actual 570.25 remaining 229.75", report.Lines[0])
+	}
+	if report.Lines[1].ActualAmount != "0.00" || report.Lines[1].RemainingAmount != "500.00" {
+		t.Fatalf("savings line = %+v, want zero actual and full remaining", report.Lines[1])
+	}
+	if report.Totals.UncategorizedActualAmount != "123.45" {
+		t.Fatalf("uncategorized = %q, want 123.45", report.Totals.UncategorizedActualAmount)
+	}
+}
+```
+
+Add helper if missing:
+
+```go
+func int64Ptr(value int64) *int64 {
+	return &value
+}
+```
+
+- [ ] **Step 2: Add failing refund test**
+
+Append:
+
+```go
+func TestGetBudgetReportNegativeTransactionsReduceActuals(t *testing.T) {
+	householdID := int64(1)
+	repo := &fakeRepo{
+		budgetByID: sqlc.Budget{
+			ID:          12,
+			HouseholdID: &householdID,
+			PeriodStart: pgtype.Date{Time: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC), Valid: true},
+			PeriodEnd:   pgtype.Date{Time: time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC), Valid: true},
+		},
+		budgetLines: []sqlc.BudgetLine{
+			{ID: 44, BudgetID: 12, Name: "Groceries", AllocationAmount: "100.00", SortOrder: 1},
+		},
+		budgetLineCategories: []sqlc.ListBudgetLineCategoriesRow{
+			{BudgetID: 12, BudgetLineID: 44, CategoryID: 3, CategoryCode: "groceries", CategoryName: "Groceries"},
+		},
+		budgetTransactions: []sqlc.ListBudgetTransactionsRow{
+			{CategoryID: int64Ptr(3), ActualAmount: 60.00},
+		},
+	}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	report, err := svc.GetBudgetReport(context.Background(), 12)
+
+	if err != nil {
+		t.Fatalf("GetBudgetReport returned error: %v", err)
+	}
+	if report.Lines[0].ActualAmount != "60.00" || report.Lines[0].RemainingAmount != "40.00" {
+		t.Fatalf("line = %+v, want net actual 60.00 remaining 40.00", report.Lines[0])
+	}
+}
+```
+
+- [ ] **Step 3: Run tests and verify they fail**
+
+Run:
+
+```bash
+go test ./internal/app
+```
+
+Expected: FAIL with undefined `GetBudgetReport`, `BudgetReportDTO`, and fake fields.
+
+- [ ] **Step 4: Add report DTOs and formatting helpers**
+
+In `internal/app/budgets.go`, add:
+
+```go
+type BudgetReportDTO struct {
+	Budget BudgetSummaryDTO        `json:"budget"`
+	Lines  []BudgetReportLineDTO   `json:"lines"`
+	Totals BudgetReportTotalsDTO   `json:"totals"`
+}
+
+type BudgetSummaryDTO struct {
+	ID             int64     `json:"id"`
+	HouseholdID    *int64    `json:"householdId,omitempty"`
+	UserID         *int64    `json:"userId,omitempty"`
+	PeriodStart    time.Time `json:"periodStart"`
+	PeriodEnd      time.Time `json:"periodEnd"`
+	SourceBudgetID *int64    `json:"sourceBudgetId,omitempty"`
+}
+
+type BudgetReportLineDTO struct {
+	ID               int64            `json:"id"`
+	BudgetID         int64            `json:"budgetId"`
+	Name             string           `json:"name"`
+	AllocationAmount string           `json:"allocationAmount"`
+	ActualAmount     string           `json:"actualAmount"`
+	RemainingAmount  string           `json:"remainingAmount"`
+	SortOrder        int32            `json:"sortOrder"`
+	Categories       []CategoryRefDTO `json:"categories"`
+}
+
+type BudgetReportTotalsDTO struct {
+	AllocationAmount           string `json:"allocationAmount"`
+	ActualAmount               string `json:"actualAmount"`
+	RemainingAmount            string `json:"remainingAmount"`
+	UncategorizedActualAmount  string `json:"uncategorizedActualAmount"`
+}
+
+func moneyString(value float64) string {
+	return fmt.Sprintf("%.2f", value)
+}
+
+func parseMoney(value string) (float64, error) {
+	parsed, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+	if err != nil {
+		return 0, err
+	}
+	return parsed, nil
+}
+```
+
+Add `fmt` to the import block.
+
+- [ ] **Step 5: Implement `GetBudgetReport`**
+
+In `internal/app/budgets.go`, add:
+
+```go
+func (s *Service) GetBudgetReport(ctx context.Context, budgetID int64) (BudgetReportDTO, error) {
+	if budgetID == 0 {
+		return BudgetReportDTO{}, NewError(CodeValidationError, "budget id is required", nil)
+	}
+	budget, err := s.repo.GetBudgetById(ctx, budgetID)
+	if err != nil {
+		return BudgetReportDTO{}, mapBudgetError(err)
+	}
+	lines, err := s.repo.ListBudgetLines(ctx, budgetID)
+	if err != nil {
+		return BudgetReportDTO{}, mapBudgetError(err)
+	}
+	mappings, err := s.repo.ListBudgetLineCategories(ctx, budgetID)
+	if err != nil {
+		return BudgetReportDTO{}, mapBudgetError(err)
+	}
+	actualRows, err := s.repo.ListBudgetTransactions(ctx, sqlc.ListBudgetTransactionsParams{
+		PeriodStart: pgtype.Date{Time: budget.PeriodStart.Time, Valid: true},
+		PeriodEnd:   pgtype.Date{Time: budget.PeriodEnd.Time, Valid: true},
+		HouseholdID: budget.HouseholdID,
+		UserID:      budget.UserID,
+	})
+	if err != nil {
+		return BudgetReportDTO{}, mapBudgetError(err)
+	}
+	uncategorized, err := s.repo.SumUncategorizedBudgetTransactions(ctx, sqlc.SumUncategorizedBudgetTransactionsParams{
+		PeriodStart: pgtype.Date{Time: budget.PeriodStart.Time, Valid: true},
+		PeriodEnd:   pgtype.Date{Time: budget.PeriodEnd.Time, Valid: true},
+		HouseholdID: budget.HouseholdID,
+		UserID:      budget.UserID,
+	})
+	if err != nil {
+		return BudgetReportDTO{}, mapBudgetError(err)
+	}
+
+	actualByCategory := make(map[int64]float64)
+	for _, row := range actualRows {
+		if row.CategoryID != nil {
+			actualByCategory[*row.CategoryID] = float64(row.ActualAmount)
+		}
+	}
+	categoriesByLine := make(map[int64][]CategoryRefDTO)
+	categoryIDsByLine := make(map[int64][]int64)
+	for _, row := range mappings {
+		categoriesByLine[row.BudgetLineID] = append(categoriesByLine[row.BudgetLineID], CategoryRefDTO{
+			ID:   row.CategoryID,
+			Code: row.CategoryCode,
+			Name: row.CategoryName,
+		})
+		categoryIDsByLine[row.BudgetLineID] = append(categoryIDsByLine[row.BudgetLineID], row.CategoryID)
+	}
+
+	reportLines := make([]BudgetReportLineDTO, 0, len(lines))
+	var totalAllocation float64
+	var totalActual float64
+	for _, line := range lines {
+		allocation, err := parseMoney(line.AllocationAmount)
+		if err != nil {
+			return BudgetReportDTO{}, NewError(CodeDatabaseError, "invalid budget allocation amount", err)
+		}
+		actual := 0.0
+		for _, categoryID := range categoryIDsByLine[line.ID] {
+			actual += actualByCategory[categoryID]
+		}
+		totalAllocation += allocation
+		totalActual += actual
+		reportLines = append(reportLines, BudgetReportLineDTO{
+			ID:               line.ID,
+			BudgetID:         line.BudgetID,
+			Name:             line.Name,
+			AllocationAmount: moneyString(allocation),
+			ActualAmount:     moneyString(actual),
+			RemainingAmount:  moneyString(allocation - actual),
+			SortOrder:        line.SortOrder,
+			Categories:       categoriesByLine[line.ID],
+		})
+	}
+
+	return BudgetReportDTO{
+		Budget: BudgetSummaryDTO{
+			ID:             budget.ID,
+			HouseholdID:    budget.HouseholdID,
+			UserID:         budget.UserID,
+			PeriodStart:    budget.PeriodStart.Time,
+			PeriodEnd:      budget.PeriodEnd.Time,
+			SourceBudgetID: budget.SourceBudgetID,
+		},
+		Lines: reportLines,
+		Totals: BudgetReportTotalsDTO{
+			AllocationAmount:          moneyString(totalAllocation),
+			ActualAmount:              moneyString(totalActual),
+			RemainingAmount:           moneyString(totalAllocation - totalActual),
+			UncategorizedActualAmount: moneyString(float64(uncategorized)),
+		},
+	}, nil
+}
+```
+
+- [ ] **Step 6: Update fake repo for reports**
+
+In `internal/app/test_fakes_test.go`, add fields:
+
+```go
+budgetTransactions               []sqlc.ListBudgetTransactionsRow
+uncategorizedBudgetTransactions  float32
+```
+
+Replace report stubs:
+
+```go
+func (f *fakeRepo) ListBudgetTransactions(context.Context, sqlc.ListBudgetTransactionsParams) ([]sqlc.ListBudgetTransactionsRow, error) {
+	return f.budgetTransactions, nil
+}
+
+func (f *fakeRepo) SumUncategorizedBudgetTransactions(context.Context, sqlc.SumUncategorizedBudgetTransactionsParams) (float32, error) {
+	return f.uncategorizedBudgetTransactions, nil
+}
+```
+
+- [ ] **Step 7: Run tests**
+
+Run:
+
+```bash
+go test ./internal/app
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit report service**
+
+Run:
+
+```bash
+git add internal/app/budgets.go internal/app/budgets_test.go internal/app/test_fakes_test.go
+git commit -m "Add budget report service"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 6: Budget CLI Commands
+
+**Files:**
+- Modify: `internal/cli/commands.go`
+- Modify: `internal/cli/commands_test.go`
+
+- [ ] **Step 1: Add failing CLI tests**
+
+Append to `internal/cli/commands_test.go`:
+
+```go
+func TestKongBudgetsGetHouseholdCreate(t *testing.T) {
+	svc := &fakeAppService{}
+	code := Run(context.Background(), []string{
+		"budgets", "get",
+		"--household-id", "1",
+		"--month", "2026-05",
+		"--create",
+	}, nil, &bytes.Buffer{}, &bytes.Buffer{}, svc)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if svc.getMonthlyBudget.HouseholdID == nil || *svc.getMonthlyBudget.HouseholdID != 1 {
+		t.Fatalf("HouseholdID = %v, want 1", svc.getMonthlyBudget.HouseholdID)
+	}
+	if svc.getMonthlyBudget.Year != 2026 || svc.getMonthlyBudget.Month != 5 || !svc.getMonthlyBudget.CreateIfMissing {
+		t.Fatalf("getMonthlyBudget = %+v, want May 2026 create", svc.getMonthlyBudget)
+	}
+}
+
+func TestKongBudgetsReport(t *testing.T) {
+	svc := &fakeAppService{}
+	code := Run(context.Background(), []string{
+		"budgets", "report", "12",
+	}, nil, &bytes.Buffer{}, &bytes.Buffer{}, svc)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if svc.getBudgetReportID != 12 {
+		t.Fatalf("report id = %d, want 12", svc.getBudgetReportID)
+	}
+}
+
+func TestKongBudgetLinesAdd(t *testing.T) {
+	svc := &fakeAppService{}
+	code := Run(context.Background(), []string{
+		"budgets", "lines", "add",
+		"--budget-id", "12",
+		"--name", "Groceries",
+		"--amount", "800.00",
+		"--categories", "groceries,costco",
+	}, nil, &bytes.Buffer{}, &bytes.Buffer{}, svc)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if svc.createBudgetLine.BudgetID != 12 || svc.createBudgetLine.Name != "Groceries" {
+		t.Fatalf("createBudgetLine = %+v, want budget 12 groceries", svc.createBudgetLine)
+	}
+	if len(svc.createBudgetLine.CategoryCodes) != 2 || svc.createBudgetLine.CategoryCodes[1] != "costco" {
+		t.Fatalf("CategoryCodes = %v, want groceries,costco", svc.createBudgetLine.CategoryCodes)
+	}
+}
+
+func TestKongBudgetLinesUpdateUsesPositionalLineID(t *testing.T) {
+	svc := &fakeAppService{}
+	code := Run(context.Background(), []string{
+		"budgets", "lines", "update", "44",
+		"--amount", "900.00",
+	}, nil, &bytes.Buffer{}, &bytes.Buffer{}, svc)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if svc.updateBudgetLine.LineID != 44 || svc.updateBudgetLine.AllocationAmount == nil || *svc.updateBudgetLine.AllocationAmount != "900.00" {
+		t.Fatalf("updateBudgetLine = %+v, want line 44 amount 900.00", svc.updateBudgetLine)
+	}
+}
+
+func TestKongBudgetLinesDeleteUsesPositionalLineID(t *testing.T) {
+	svc := &fakeAppService{}
+	code := Run(context.Background(), []string{
+		"budgets", "lines", "delete", "44",
+	}, nil, &bytes.Buffer{}, &bytes.Buffer{}, svc)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if svc.deleteBudgetLineID != 44 {
+		t.Fatalf("deleteBudgetLineID = %d, want 44", svc.deleteBudgetLineID)
+	}
+}
+```
+
+- [ ] **Step 2: Run CLI tests and verify they fail**
+
+Run:
+
+```bash
+go test ./internal/cli
+```
+
+Expected: FAIL because budget CLI commands and fake methods do not exist.
+
+- [ ] **Step 3: Add budget methods to `AppService`**
+
+In `internal/cli/commands.go`, extend `AppService`:
+
+```go
+	GetMonthlyBudget(context.Context, app.GetMonthlyBudgetRequest) (app.BudgetDTO, error)
+	CreateBudgetLine(context.Context, app.CreateBudgetLineRequest) (app.BudgetLineDTO, error)
+	UpdateBudgetLine(context.Context, app.UpdateBudgetLineRequest) (app.BudgetLineDTO, error)
+	DeleteBudgetLine(context.Context, int64) error
+	GetBudgetReport(context.Context, int64) (app.BudgetReportDTO, error)
+```
+
+- [ ] **Step 4: Add `budgets` command group**
+
+In `internal/cli/commands.go`, add to `CLI`:
+
+```go
+	Budgets     BudgetsCmd     `cmd:"" help:"Manage budgets."`
+```
+
+Add command structs:
+
+```go
+type BudgetsCmd struct {
+	Get    BudgetGetCmd    `cmd:"" help:"Get a monthly budget."`
+	Report BudgetReportCmd `cmd:"" help:"Show a budget report."`
+	Lines  BudgetLinesCmd  `cmd:"" help:"Manage budget lines."`
+}
+
+type BudgetGetCmd struct {
+	HouseholdID *int64 `placeholder:"INT-64" help:"Household budget owner."`
+	UserID      *int64 `placeholder:"INT-64" help:"Personal budget owner."`
+	Month       string `required:"" help:"Budget month in YYYY-MM format."`
+	Create      bool   `help:"Create the monthly budget if missing."`
+}
+
+func (c *BudgetGetCmd) Run(ctx *runContext) error {
+	year, month, err := parseBudgetMonth(c.Month)
+	if err != nil {
+		return err
+	}
+	budget, err := ctx.svc.GetMonthlyBudget(ctx.Context, app.GetMonthlyBudgetRequest{
+		HouseholdID:     c.HouseholdID,
+		UserID:          c.UserID,
+		Year:            year,
+		Month:           month,
+		CreateIfMissing: c.Create,
+	})
+	if err != nil {
+		return err
+	}
+	return RenderJSON(ctx.stdout, budget)
+}
+
+type BudgetReportCmd struct {
+	ID int64 `arg:"" required:"" help:"Budget ID."`
+}
+
+func (c *BudgetReportCmd) Run(ctx *runContext) error {
+	report, err := ctx.svc.GetBudgetReport(ctx.Context, c.ID)
+	if err != nil {
+		return err
+	}
+	return RenderJSON(ctx.stdout, report)
+}
+
+type BudgetLinesCmd struct {
+	Add    BudgetLineAddCmd    `cmd:"" help:"Add a budget line."`
+	Update BudgetLineUpdateCmd `cmd:"" help:"Update a budget line."`
+	Delete BudgetLineDeleteCmd `cmd:"" help:"Delete a budget line."`
+}
+
+type BudgetLineAddCmd struct {
+	BudgetID   int64   `required:"" placeholder:"INT-64" help:"Budget ID."`
+	Name       string  `required:"" help:"Budget line name."`
+	Amount     string  `required:"" help:"Allocation amount."`
+	Categories *string `help:"Comma-separated category codes."`
+	SortOrder  *int32  `help:"Display sort order."`
+}
+
+func (c *BudgetLineAddCmd) Run(ctx *runContext) error {
+	line, err := ctx.svc.CreateBudgetLine(ctx.Context, app.CreateBudgetLineRequest{
+		BudgetID:         c.BudgetID,
+		Name:             c.Name,
+		AllocationAmount: c.Amount,
+		CategoryCodes:    parseOptionalCSV(c.Categories),
+		SortOrder:        c.SortOrder,
+	})
+	if err != nil {
+		return err
+	}
+	return RenderJSON(ctx.stdout, line)
+}
+
+type BudgetLineUpdateCmd struct {
+	ID         int64   `arg:"" required:"" help:"Budget line ID."`
+	Name       *string `help:"Replacement budget line name."`
+	Amount     *string `help:"Replacement allocation amount."`
+	Categories *string `help:"Replacement comma-separated category codes."`
+	SortOrder  *int32  `help:"Replacement display sort order."`
+}
+
+func (c *BudgetLineUpdateCmd) Run(ctx *runContext) error {
+	var categoryCodes *[]string
+	if c.Categories != nil {
+		parsed := parseOptionalCSV(c.Categories)
+		categoryCodes = &parsed
+	}
+	line, err := ctx.svc.UpdateBudgetLine(ctx.Context, app.UpdateBudgetLineRequest{
+		LineID:           c.ID,
+		Name:             c.Name,
+		AllocationAmount: c.Amount,
+		CategoryCodes:    categoryCodes,
+		SortOrder:        c.SortOrder,
+	})
+	if err != nil {
+		return err
+	}
+	return RenderJSON(ctx.stdout, line)
+}
+
+type BudgetLineDeleteCmd struct {
+	ID int64 `arg:"" required:"" help:"Budget line ID."`
+}
+
+func (c *BudgetLineDeleteCmd) Run(ctx *runContext) error {
+	return ctx.svc.DeleteBudgetLine(ctx.Context, c.ID)
+}
+```
+
+- [ ] **Step 5: Add parsing helpers**
+
+In `internal/cli/commands.go`, add:
+
+```go
+func parseBudgetMonth(value string) (int, int, error) {
+	parsed, err := time.Parse("2006-01", value)
+	if err != nil {
+		return 0, 0, fmt.Errorf("month must be in YYYY-MM format")
+	}
+	return parsed.Year(), int(parsed.Month()), nil
+}
+
+func parseOptionalCSV(value *string) []string {
+	if value == nil || strings.TrimSpace(*value) == "" {
+		return nil
+	}
+	parts := strings.Split(*value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+```
+
+`fmt`, `strings`, and `time` are already imported in `commands.go`; reuse the existing imports.
+
+- [ ] **Step 6: Update fake CLI service**
+
+In `internal/cli/commands_test.go`, add fields to `fakeAppService`:
+
+```go
+getMonthlyBudget  app.GetMonthlyBudgetRequest
+createBudgetLine  app.CreateBudgetLineRequest
+updateBudgetLine  app.UpdateBudgetLineRequest
+deleteBudgetLineID int64
+getBudgetReportID int64
+```
+
+Add methods:
+
+```go
+func (f *fakeAppService) GetMonthlyBudget(_ context.Context, req app.GetMonthlyBudgetRequest) (app.BudgetDTO, error) {
+	f.getMonthlyBudget = req
+	return app.BudgetDTO{ID: 12}, nil
+}
+
+func (f *fakeAppService) CreateBudgetLine(_ context.Context, req app.CreateBudgetLineRequest) (app.BudgetLineDTO, error) {
+	f.createBudgetLine = req
+	return app.BudgetLineDTO{ID: 44, BudgetID: req.BudgetID, Name: req.Name, AllocationAmount: req.AllocationAmount}, nil
+}
+
+func (f *fakeAppService) UpdateBudgetLine(_ context.Context, req app.UpdateBudgetLineRequest) (app.BudgetLineDTO, error) {
+	f.updateBudgetLine = req
+	amount := ""
+	if req.AllocationAmount != nil {
+		amount = *req.AllocationAmount
+	}
+	return app.BudgetLineDTO{ID: req.LineID, AllocationAmount: amount}, nil
+}
+
+func (f *fakeAppService) DeleteBudgetLine(_ context.Context, id int64) error {
+	f.deleteBudgetLineID = id
+	return nil
+}
+
+func (f *fakeAppService) GetBudgetReport(_ context.Context, id int64) (app.BudgetReportDTO, error) {
+	f.getBudgetReportID = id
+	return app.BudgetReportDTO{}, nil
+}
+```
+
+- [ ] **Step 7: Run CLI tests**
+
+Run:
+
+```bash
+go test ./internal/cli
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit CLI commands**
+
+Run:
+
+```bash
+git add internal/cli/commands.go internal/cli/commands_test.go
+git commit -m "Add budget CLI commands"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 7: CLI Documentation and Full Verification
+
+**Files:**
+- Modify: `docs/cli.md`
+
+- [ ] **Step 1: Update CLI docs**
+
+Add a `## Budgets` section to `docs/cli.md` after `## Households`:
+
+```markdown
+## Budgets
+
+Get or create a household monthly budget. When `--create` is provided and the month does not exist, the app copies the latest prior budget for the same owner. If no prior budget exists, it creates an empty budget.
+
+```bash
+/tmp/voltr-finance --config /tmp/voltr-finance.json budgets get \
+  --household-id 1 \
+  --month 2026-05 \
+  --create
+```
+
+Get or create a personal monthly budget:
+
+```bash
+/tmp/voltr-finance --config /tmp/voltr-finance.json budgets get \
+  --user-id 4 \
+  --month 2026-05 \
+  --create
+```
+
+Add a budget line. Category inputs use category codes:
+
+```bash
+/tmp/voltr-finance --config /tmp/voltr-finance.json budgets lines add \
+  --budget-id 12 \
+  --name "Groceries" \
+  --amount 800.00 \
+  --categories groceries,costco
+```
+
+Update a budget line by line ID:
+
+```bash
+/tmp/voltr-finance --config /tmp/voltr-finance.json budgets lines update 44 \
+  --amount 900.00
+```
+
+Delete a budget line by line ID:
+
+```bash
+/tmp/voltr-finance --config /tmp/voltr-finance.json budgets lines delete 44
+```
+
+Show budget actuals:
+
+```bash
+/tmp/voltr-finance --config /tmp/voltr-finance.json budgets report 12
+```
+```
+
+- [ ] **Step 2: Run all tests**
+
+Run:
+
+```bash
+go test ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Build CLI**
+
+Run:
+
+```bash
+go build ./cmd/cli
+```
+
+Expected: PASS with exit code 0.
+
+- [ ] **Step 4: Search for stale budget category references**
+
+Run:
+
+```bash
+grep -RIn "budget_category_id\|BudgetCategoryID\|budget_category" internal db/migrations docs/superpowers/specs/2026-05-10-budget-design.md
+```
+
+Expected: only historical migration down sections and existing category design/plan references may appear. No new budget implementation file should introduce `budget_category` or `BudgetCategoryID`.
+
+- [ ] **Step 5: Commit docs and final verification state**
+
+Run:
+
+```bash
+git add docs/cli.md
+git commit -m "Document budget CLI commands"
+```
+
+Expected: commit succeeds.
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: clean worktree.
+
+---
+
+## Self-Review Checklist
+
+- Spec coverage: tasks cover normalized data model, monthly date ranges, household and personal owners, latest-prior auto-copy, line-level create/update/delete, category-code CLI inputs, derived reporting, refund netting, uncategorized visibility, and CLI docs.
+- Placeholder scan: no implementation step depends on unspecified behavior; code snippets define the intended functions, methods, requests, and commands.
+- Type consistency: all service and CLI names use `GetMonthlyBudget`, `CreateBudgetLine`, `UpdateBudgetLine`, `DeleteBudgetLine`, and `GetBudgetReport`; CLI update/delete use positional line IDs; CLI create uses `--budget-id`.

--- a/docs/superpowers/specs/2026-05-10-budget-design.md
+++ b/docs/superpowers/specs/2026-05-10-budget-design.md
@@ -1,0 +1,391 @@
+# Budget Design
+
+## Purpose
+
+Add simple monthly budgets for both households and individual users. A budget is a dated allocation plan made of budget lines such as rent, utilities, groceries, dates, dog food, and savings.
+
+Budgets integrate with the existing transaction category feature. Transactions do not point directly to budget lines. Instead, budget actuals are derived from transaction categories mapped to each budget line.
+
+## Goals
+
+- Support household budgets and personal budgets.
+- Store budgets as monthly snapshots with explicit date ranges.
+- Keep the app surface monthly-only for now, even though the data model stores date ranges.
+- Automatically create a missing monthly budget from the latest prior budget for the same owner when requested with create behavior.
+- Let each budget line map to zero, one, or many existing categories.
+- Prevent one category from counting against multiple lines in the same budget.
+- Keep savings possible as an unmapped budget line.
+- Keep salary out of the first budget model.
+- Derive actual spending from categorized transactions.
+
+## Non-Goals
+
+- No income or salary tracking.
+- No budget-line split allocation by user or percentage.
+- No direct `transaction.budget_line_id` reference.
+- No custom non-monthly periods in the app API.
+- No scheduler that pre-creates future budgets.
+- No hard requirement to support bulk replacement as the primary editing path.
+
+## Data Model
+
+Reuse the existing `budget` table concept, but make it the monthly budget snapshot record.
+
+```sql
+CREATE TABLE budget (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    household_id BIGINT REFERENCES household(id),
+    user_id BIGINT REFERENCES users(id),
+    period_start DATE NOT NULL,
+    period_end DATE NOT NULL,
+    source_budget_id BIGINT REFERENCES budget(id),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    CHECK (
+        (household_id IS NOT NULL AND user_id IS NULL)
+        OR
+        (household_id IS NULL AND user_id IS NOT NULL)
+    ),
+    CHECK (period_end >= period_start)
+);
+```
+
+Use partial unique indexes so each owner has at most one budget for a date range:
+
+```sql
+CREATE UNIQUE INDEX idx_budget_household_period
+ON budget(household_id, period_start, period_end)
+WHERE household_id IS NOT NULL;
+
+CREATE UNIQUE INDEX idx_budget_user_period
+ON budget(user_id, period_start, period_end)
+WHERE user_id IS NOT NULL;
+```
+
+Budget lines are normalized records. Each line is a planned allocation in one monthly budget.
+
+```sql
+CREATE TABLE budget_line (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    budget_id BIGINT NOT NULL REFERENCES budget(id) ON DELETE CASCADE,
+    name VARCHAR NOT NULL,
+    allocation_amount NUMERIC(12, 2) NOT NULL,
+    sort_order INTEGER NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    CHECK (allocation_amount >= 0),
+    UNIQUE (budget_id, id),
+    UNIQUE (budget_id, sort_order)
+);
+```
+
+Budget line category mappings connect allocation lines to existing transaction categories.
+
+```sql
+CREATE TABLE budget_line_category (
+    budget_id BIGINT NOT NULL REFERENCES budget(id) ON DELETE CASCADE,
+    budget_line_id BIGINT NOT NULL,
+    category_id BIGINT NOT NULL REFERENCES category(id),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (budget_line_id, category_id),
+    FOREIGN KEY (budget_id, budget_line_id)
+        REFERENCES budget_line(budget_id, id)
+        ON DELETE CASCADE,
+    UNIQUE (budget_id, category_id)
+);
+```
+
+The denormalized `budget_id` on `budget_line_category` is intentional. It lets the database enforce that a category can only be mapped once within a budget, which prevents double-counted actuals.
+
+## Monthly Period Rules
+
+The database stores `period_start` and `period_end`, but the app only exposes monthly budgets in the first version.
+
+For a requested `year` and `month`, the service computes:
+
+```text
+period_start = first day of requested month
+period_end = last day of requested month
+```
+
+Example:
+
+```text
+May 2026 -> period_start 2026-05-01, period_end 2026-05-31
+```
+
+The first implementation does not need database overlap constraints because app-created budgets are monthly and exact owner/range uniqueness is enough for the supported behavior.
+
+## Service Behavior
+
+### Get Monthly Budget
+
+```go
+GetMonthlyBudget(ctx, req GetMonthlyBudgetRequest) (BudgetDTO, error)
+```
+
+Request fields:
+
+- `HouseholdID *int64`
+- `UserID *int64`
+- `Year int`
+- `Month int`
+- `CreateIfMissing bool`
+
+Behavior:
+
+- Validate exactly one owner selector is present.
+- Convert `Year` and `Month` into the monthly period range.
+- Return the existing budget when found.
+- If no budget exists and `CreateIfMissing` is false, return a not-found error.
+- If no budget exists and `CreateIfMissing` is true:
+  - find the latest prior budget for the same owner by `period_start`;
+  - create a new budget for the requested month;
+  - set `source_budget_id` to the copied budget when one exists;
+  - copy all budget lines as new rows;
+  - copy all category mappings for those copied lines;
+  - create an empty budget when no prior budget exists.
+
+Copying from the latest prior budget should work even when there are month gaps. If May exists and June does not, requesting July with create behavior should copy May.
+
+### Create Budget Line
+
+```go
+CreateBudgetLine(ctx, req CreateBudgetLineRequest) (BudgetLineDTO, error)
+```
+
+Request fields:
+
+- `BudgetID int64`
+- `Name string`
+- `AllocationAmount decimal`
+- `CategoryIDs []int64`
+- `CategoryCodes []string`
+- `SortOrder *int`
+
+Behavior:
+
+- Validate the budget exists.
+- Validate name is present.
+- Validate allocation amount is greater than or equal to zero.
+- Resolve supplied category codes to active categories.
+- Validate supplied category IDs reference active categories.
+- Validate no category is already mapped to a different line in the same budget.
+- If `SortOrder` is omitted, append the line after the current maximum sort order for the budget.
+- Create the line and mappings in one transaction.
+
+Category codes are expected for CLI ergonomics. Database rows store category IDs.
+
+### Update Budget Line
+
+```go
+UpdateBudgetLine(ctx, req UpdateBudgetLineRequest) (BudgetLineDTO, error)
+```
+
+Request fields:
+
+- `LineID int64`
+- `Name *string`
+- `AllocationAmount *decimal`
+- `CategoryIDs *[]int64`
+- `CategoryCodes *[]string`
+- `SortOrder *int`
+
+Behavior:
+
+- Validate the line exists.
+- Apply only provided fields.
+- If categories are provided, replace mappings for that line only.
+- Validate replacement categories are active and not already mapped to another line in the same budget.
+- Do not affect other budget lines.
+
+### Delete Budget Line
+
+```go
+DeleteBudgetLine(ctx, lineID int64) error
+```
+
+Behavior:
+
+- Delete the line and its category mappings.
+- Do not modify transactions.
+- Hard delete is acceptable in the first version because budget lines are editable planning rows within a monthly snapshot.
+
+### Get Budget Report
+
+```go
+GetBudgetReport(ctx, budgetID int64) (BudgetReportDTO, error)
+```
+
+Behavior:
+
+- Load the budget, lines, and category mappings.
+- Load transactions for the same owner and period.
+- Ignore deleted transactions.
+- Ignore transactions without categories for line actuals.
+- Match transactions to budget lines through `transaction.category_id` and `budget_line_category.category_id`.
+- Sum transaction amounts directly:
+  - positive expense amounts increase actual spending;
+  - negative refund amounts reduce actual spending.
+- Return allocated amount, actual amount, and remaining amount for each line.
+- Include report totals.
+- Include uncategorized actual amount separately if useful for visibility, but do not count it against any line.
+
+Remaining amount is:
+
+```text
+allocation_amount - actual_amount
+```
+
+## DTO Shape
+
+Budget responses should include the owner, period, source budget, and lines.
+
+```json
+{
+  "id": 12,
+  "householdId": 1,
+  "periodStart": "2026-05-01",
+  "periodEnd": "2026-05-31",
+  "sourceBudgetId": 11,
+  "lines": [
+    {
+      "id": 44,
+      "name": "Groceries",
+      "allocationAmount": "800.00",
+      "sortOrder": 1,
+      "categories": [
+        { "id": 1, "code": "groceries", "name": "Groceries" }
+      ]
+    }
+  ]
+}
+```
+
+Report responses should include the same line structure with actuals.
+
+```json
+{
+  "budget": {
+    "id": 12,
+    "householdId": 1,
+    "periodStart": "2026-05-01",
+    "periodEnd": "2026-05-31",
+    "sourceBudgetId": 11
+  },
+  "lines": [
+    {
+      "id": 44,
+      "name": "Groceries",
+      "allocationAmount": "800.00",
+      "actualAmount": "570.25",
+      "remainingAmount": "229.75",
+      "sortOrder": 1,
+      "categories": [
+        { "id": 1, "code": "groceries", "name": "Groceries" }
+      ]
+    }
+  ],
+  "totals": {
+    "allocationAmount": "4000.00",
+    "actualAmount": "2850.00",
+    "remainingAmount": "1150.00",
+    "uncategorizedActualAmount": "123.45"
+  }
+}
+```
+
+## CLI Behavior
+
+Use a `budgets` command group.
+
+Get or create a household monthly budget:
+
+```bash
+voltr-finance budgets get --household-id 1 --month 2026-05 --create
+```
+
+Get or create a personal monthly budget:
+
+```bash
+voltr-finance budgets get --user-id 4 --month 2026-05 --create
+```
+
+Get a report:
+
+```bash
+voltr-finance budgets report 12
+```
+
+Add a line:
+
+```bash
+voltr-finance budgets lines add \
+  --budget-id 12 \
+  --name "Groceries" \
+  --amount 800 \
+  --categories groceries,costco
+```
+
+Update a line by positional line ID:
+
+```bash
+voltr-finance budgets lines update 44 --amount 900
+voltr-finance budgets lines update 44 --categories groceries,costco,supermarket
+```
+
+Delete a line by positional line ID:
+
+```bash
+voltr-finance budgets lines delete 44
+```
+
+Category inputs in the CLI should use category codes. The service resolves them to category IDs before storing mappings.
+
+## Validation and Errors
+
+Budget validation:
+
+- Exactly one owner selector is required.
+- Year and month must identify a valid calendar month.
+- The owner must exist.
+- A duplicate owner/month budget should be treated as the existing budget during create-if-missing behavior.
+
+Line validation:
+
+- Name is required.
+- Allocation amount must be greater than or equal to zero.
+- Category IDs/codes must reference active categories.
+- A category cannot appear in more than one line in the same budget.
+- Sort order must be unique within a budget when explicitly provided.
+
+Use existing app error patterns for validation, not-found, and database errors.
+
+## Testing
+
+Add focused tests for:
+
+- Monthly period calculation.
+- Budget owner validation for household and personal budgets.
+- Creating an empty monthly budget when no prior budget exists.
+- Auto-copying from the latest prior budget with copied lines and category mappings.
+- Auto-copying from latest prior budget when month gaps exist.
+- Creating a budget line with category codes.
+- Rejecting inactive or unknown categories.
+- Rejecting category reuse across lines in the same budget.
+- Updating one line without affecting other lines.
+- Replacing category mappings for one line.
+- Deleting a line without touching transactions.
+- Budget report actuals derived from transaction categories.
+- Negative refund transactions reducing actual spending.
+- Uncategorized transactions excluded from line actuals and surfaced separately.
+- CLI parsing for `budgets get`, `budgets report`, `budgets lines add`, `budgets lines update`, and `budgets lines delete`.
+
+## Future Extensions
+
+- Bulk import or set-all-lines helper for initial setup.
+- Split allocation per budget line by user, percentage, or fixed amount.
+- Budget templates if monthly copy behavior stops being enough.
+- Manual transaction-to-budget override for exceptional transactions.
+- Income/cashflow tracking for salary and other income sources.
+- Gross spend and refund breakdown in budget reports.

--- a/internal/app/budgets.go
+++ b/internal/app/budgets.go
@@ -1,0 +1,241 @@
+package app
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"rdmm404/voltr-finance/internal/database/sqlc"
+)
+
+type GetMonthlyBudgetRequest struct {
+	HouseholdID     *int64 `json:"householdId,omitempty"`
+	UserID          *int64 `json:"userId,omitempty"`
+	Year            int    `json:"year"`
+	Month           int    `json:"month"`
+	CreateIfMissing bool   `json:"createIfMissing,omitempty"`
+}
+
+type BudgetDTO struct {
+	ID             int64           `json:"id"`
+	HouseholdID    *int64          `json:"householdId,omitempty"`
+	UserID         *int64          `json:"userId,omitempty"`
+	PeriodStart    time.Time       `json:"periodStart"`
+	PeriodEnd      time.Time       `json:"periodEnd"`
+	SourceBudgetID *int64          `json:"sourceBudgetId,omitempty"`
+	Lines          []BudgetLineDTO `json:"lines"`
+}
+
+type BudgetLineDTO struct {
+	ID               int64            `json:"id"`
+	BudgetID         int64            `json:"budgetId"`
+	Name             string           `json:"name"`
+	AllocationAmount string           `json:"allocationAmount"`
+	SortOrder        int32            `json:"sortOrder"`
+	Categories       []CategoryRefDTO `json:"categories"`
+}
+
+func (s *Service) GetMonthlyBudget(ctx context.Context, req GetMonthlyBudgetRequest) (BudgetDTO, error) {
+	if err := validateBudgetOwner(req.HouseholdID, req.UserID); err != nil {
+		return BudgetDTO{}, err
+	}
+
+	start, end, err := monthlyBudgetPeriod(req.Year, req.Month)
+	if err != nil {
+		return BudgetDTO{}, err
+	}
+
+	periodStart := pgtype.Date{Time: start, Valid: true}
+	periodEnd := pgtype.Date{Time: end, Valid: true}
+	budget, err := s.findBudgetByPeriod(ctx, req.HouseholdID, req.UserID, periodStart, periodEnd)
+	if err == nil {
+		return s.budgetDTO(ctx, budget)
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return BudgetDTO{}, mapBudgetError(err)
+	}
+	if !req.CreateIfMissing {
+		return BudgetDTO{}, mapBudgetError(err)
+	}
+
+	budget, err = s.createMonthlyBudget(ctx, req.HouseholdID, req.UserID, periodStart, periodEnd)
+	if err != nil {
+		return BudgetDTO{}, mapBudgetError(err)
+	}
+	return s.budgetDTO(ctx, budget)
+}
+
+func validateBudgetOwner(householdID, userID *int64) error {
+	if (householdID == nil) == (userID == nil) {
+		return NewError(CodeValidationError, "exactly one budget owner is required", nil)
+	}
+	return nil
+}
+
+func monthlyBudgetPeriod(year int, month int) (time.Time, time.Time, error) {
+	if month < 1 || month > 12 {
+		return time.Time{}, time.Time{}, NewError(CodeValidationError, "month must be between 1 and 12", nil)
+	}
+	start := time.Date(year, time.Month(month), 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 1, -1)
+	return start, end, nil
+}
+
+func (s *Service) findBudgetByPeriod(ctx context.Context, householdID, userID *int64, periodStart, periodEnd pgtype.Date) (sqlc.Budget, error) {
+	if householdID != nil {
+		return s.repo.GetHouseholdBudgetByPeriod(ctx, sqlc.GetHouseholdBudgetByPeriodParams{
+			HouseholdID: *householdID,
+			PeriodStart: periodStart,
+			PeriodEnd:   periodEnd,
+		})
+	}
+	return s.repo.GetUserBudgetByPeriod(ctx, sqlc.GetUserBudgetByPeriodParams{
+		UserID:      *userID,
+		PeriodStart: periodStart,
+		PeriodEnd:   periodEnd,
+	})
+}
+
+func (s *Service) createMonthlyBudget(ctx context.Context, householdID, userID *int64, periodStart, periodEnd pgtype.Date) (sqlc.Budget, error) {
+	if householdID != nil {
+		return s.repo.CreateHouseholdBudget(ctx, sqlc.CreateHouseholdBudgetParams{
+			HouseholdID:    *householdID,
+			PeriodStart:    periodStart,
+			PeriodEnd:      periodEnd,
+			SourceBudgetID: nil,
+		})
+	}
+	return s.repo.CreateUserBudget(ctx, sqlc.CreateUserBudgetParams{
+		UserID:         *userID,
+		PeriodStart:    periodStart,
+		PeriodEnd:      periodEnd,
+		SourceBudgetID: nil,
+	})
+}
+
+func (s *Service) budgetDTO(ctx context.Context, budget sqlc.Budget) (BudgetDTO, error) {
+	lines, err := s.repo.ListBudgetLines(ctx, budget.ID)
+	if err != nil {
+		return BudgetDTO{}, mapBudgetError(err)
+	}
+	categoryRows, err := s.repo.ListBudgetLineCategories(ctx, budget.ID)
+	if err != nil {
+		return BudgetDTO{}, mapBudgetError(err)
+	}
+
+	categoriesByLine := make(map[int64][]CategoryRefDTO)
+	for _, row := range categoryRows {
+		categoriesByLine[row.BudgetLineID] = append(categoriesByLine[row.BudgetLineID], CategoryRefDTO{
+			ID:   row.CategoryID,
+			Code: row.CategoryCode,
+			Name: row.CategoryName,
+		})
+	}
+
+	lineDTOs := make([]BudgetLineDTO, 0, len(lines))
+	for _, line := range lines {
+		lineDTOs = append(lineDTOs, budgetLineDTO(line, categoriesByLine[line.ID]))
+	}
+
+	return BudgetDTO{
+		ID:             budget.ID,
+		HouseholdID:    budget.HouseholdID,
+		UserID:         budget.UserID,
+		PeriodStart:    budget.PeriodStart.Time,
+		PeriodEnd:      budget.PeriodEnd.Time,
+		SourceBudgetID: budget.SourceBudgetID,
+		Lines:          lineDTOs,
+	}, nil
+}
+
+func budgetLineDTO(line sqlc.BudgetLine, categories []CategoryRefDTO) BudgetLineDTO {
+	if categories == nil {
+		categories = []CategoryRefDTO{}
+	}
+	return BudgetLineDTO{
+		ID:               line.ID,
+		BudgetID:         line.BudgetID,
+		Name:             line.Name,
+		AllocationAmount: budgetNumericString(line.AllocationAmount),
+		SortOrder:        line.SortOrder,
+		Categories:       categories,
+	}
+}
+
+func parseBudgetNumeric(value string) (pgtype.Numeric, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return pgtype.Numeric{}, NewError(CodeValidationError, "allocation amount is required", nil)
+	}
+	if strings.HasPrefix(value, "+") {
+		value = strings.TrimPrefix(value, "+")
+	}
+	if strings.HasPrefix(value, "-") {
+		return pgtype.Numeric{}, NewError(CodeValidationError, "allocation amount must be a decimal string", nil)
+	}
+
+	parts := strings.Split(value, ".")
+	if len(parts) > 2 || parts[0] == "" {
+		return pgtype.Numeric{}, NewError(CodeValidationError, "allocation amount must be a decimal string", nil)
+	}
+	fraction := ""
+	if len(parts) == 2 {
+		fraction = parts[1]
+		if len(fraction) > 2 {
+			return pgtype.Numeric{}, NewError(CodeValidationError, "allocation amount supports at most two decimal places", nil)
+		}
+	}
+	digits := parts[0] + fraction
+	for _, char := range digits {
+		if char < '0' || char > '9' {
+			return pgtype.Numeric{}, NewError(CodeValidationError, "allocation amount must be a decimal string", nil)
+		}
+	}
+
+	intValue := new(big.Int)
+	if _, ok := intValue.SetString(digits, 10); !ok {
+		return pgtype.Numeric{}, fmt.Errorf("parse allocation amount %q", value)
+	}
+	return pgtype.Numeric{Int: intValue, Exp: -int32(len(fraction)), Valid: true}, nil
+}
+
+func budgetNumericString(value pgtype.Numeric) string {
+	if !value.Valid || value.Int == nil {
+		return "0"
+	}
+	digits := value.Int.String()
+	if value.Exp >= 0 {
+		return digits + strings.Repeat("0", int(value.Exp))
+	}
+
+	scale := int(-value.Exp)
+	negative := strings.HasPrefix(digits, "-")
+	if negative {
+		digits = strings.TrimPrefix(digits, "-")
+	}
+	for len(digits) <= scale {
+		digits = "0" + digits
+	}
+	point := len(digits) - scale
+	result := digits[:point] + "." + digits[point:]
+	if negative {
+		result = "-" + result
+	}
+	return result
+}
+
+func mapBudgetError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return NewError(CodeValidationError, "budget not found", err)
+	}
+	return NewError(CodeDatabaseError, "database error", err)
+}

--- a/internal/app/budgets.go
+++ b/internal/app/budgets.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"math/big"
+	"strconv"
 	"strings"
 	"time"
 
@@ -38,6 +40,39 @@ type BudgetLineDTO struct {
 	AllocationAmount string           `json:"allocationAmount"`
 	SortOrder        int32            `json:"sortOrder"`
 	Categories       []CategoryRefDTO `json:"categories"`
+}
+
+type BudgetReportDTO struct {
+	Budget BudgetSummaryDTO      `json:"budget"`
+	Lines  []BudgetReportLineDTO `json:"lines"`
+	Totals BudgetReportTotalsDTO `json:"totals"`
+}
+
+type BudgetSummaryDTO struct {
+	ID             int64     `json:"id"`
+	HouseholdID    *int64    `json:"householdId,omitempty"`
+	UserID         *int64    `json:"userId,omitempty"`
+	PeriodStart    time.Time `json:"periodStart"`
+	PeriodEnd      time.Time `json:"periodEnd"`
+	SourceBudgetID *int64    `json:"sourceBudgetId,omitempty"`
+}
+
+type BudgetReportLineDTO struct {
+	ID               int64            `json:"id"`
+	BudgetID         int64            `json:"budgetId"`
+	Name             string           `json:"name"`
+	AllocationAmount string           `json:"allocationAmount"`
+	ActualAmount     string           `json:"actualAmount"`
+	RemainingAmount  string           `json:"remainingAmount"`
+	SortOrder        int32            `json:"sortOrder"`
+	Categories       []CategoryRefDTO `json:"categories"`
+}
+
+type BudgetReportTotalsDTO struct {
+	AllocationAmount          string `json:"allocationAmount"`
+	ActualAmount              string `json:"actualAmount"`
+	RemainingAmount           string `json:"remainingAmount"`
+	UncategorizedActualAmount string `json:"uncategorizedActualAmount"`
 }
 
 type CreateBudgetLineRequest struct {
@@ -405,6 +440,101 @@ func (s *Service) DeleteBudgetLine(ctx context.Context, lineID int64) error {
 	return nil
 }
 
+func (s *Service) GetBudgetReport(ctx context.Context, budgetID int64) (BudgetReportDTO, error) {
+	if budgetID == 0 {
+		return BudgetReportDTO{}, NewError(CodeValidationError, "budget id is required", nil)
+	}
+	budget, err := s.repo.GetBudgetById(ctx, budgetID)
+	if err != nil {
+		return BudgetReportDTO{}, mapBudgetError(err)
+	}
+	lines, err := s.repo.ListBudgetLines(ctx, budgetID)
+	if err != nil {
+		return BudgetReportDTO{}, mapBudgetError(err)
+	}
+	mappings, err := s.repo.ListBudgetLineCategories(ctx, budgetID)
+	if err != nil {
+		return BudgetReportDTO{}, mapBudgetError(err)
+	}
+	actualRows, err := s.repo.ListBudgetTransactions(ctx, sqlc.ListBudgetTransactionsParams{
+		PeriodStart: budget.PeriodStart,
+		PeriodEnd:   budget.PeriodEnd,
+		HouseholdID: budget.HouseholdID,
+		UserID:      budget.UserID,
+	})
+	if err != nil {
+		return BudgetReportDTO{}, mapBudgetError(err)
+	}
+	uncategorized, err := s.repo.SumUncategorizedBudgetTransactions(ctx, sqlc.SumUncategorizedBudgetTransactionsParams{
+		PeriodStart: budget.PeriodStart,
+		PeriodEnd:   budget.PeriodEnd,
+		HouseholdID: budget.HouseholdID,
+		UserID:      budget.UserID,
+	})
+	if err != nil {
+		return BudgetReportDTO{}, mapBudgetError(err)
+	}
+
+	actualByCategory := make(map[int64]float64, len(actualRows))
+	for _, row := range actualRows {
+		actualByCategory[row.CategoryID] = float64(row.ActualAmount)
+	}
+	categoriesByLine := make(map[int64][]CategoryRefDTO)
+	categoryIDsByLine := make(map[int64][]int64)
+	for _, row := range mappings {
+		categoriesByLine[row.BudgetLineID] = append(categoriesByLine[row.BudgetLineID], CategoryRefDTO{
+			ID:   row.CategoryID,
+			Code: row.CategoryCode,
+			Name: row.CategoryName,
+		})
+		categoryIDsByLine[row.BudgetLineID] = append(categoryIDsByLine[row.BudgetLineID], row.CategoryID)
+	}
+
+	reportLines := make([]BudgetReportLineDTO, 0, len(lines))
+	totalAllocation := 0.0
+	totalActual := 0.0
+	for _, line := range lines {
+		allocation, err := parseMoney(budgetNumericString(line.AllocationAmount))
+		if err != nil {
+			return BudgetReportDTO{}, NewError(CodeDatabaseError, "invalid budget allocation amount", err)
+		}
+		actual := 0.0
+		for _, categoryID := range categoryIDsByLine[line.ID] {
+			actual += actualByCategory[categoryID]
+		}
+		totalAllocation += allocation
+		totalActual += actual
+		reportLines = append(reportLines, BudgetReportLineDTO{
+			ID:               line.ID,
+			BudgetID:         line.BudgetID,
+			Name:             line.Name,
+			AllocationAmount: moneyString(allocation),
+			ActualAmount:     moneyString(actual),
+			RemainingAmount:  moneyString(allocation - actual),
+			SortOrder:        line.SortOrder,
+			Categories:       categoriesByLine[line.ID],
+		})
+	}
+
+	return BudgetReportDTO{
+		Budget: BudgetSummaryDTO{
+			ID:             budget.ID,
+			HouseholdID:    budget.HouseholdID,
+			UserID:         budget.UserID,
+			PeriodStart:    budget.PeriodStart.Time,
+			PeriodEnd:      budget.PeriodEnd.Time,
+			SourceBudgetID: budget.SourceBudgetID,
+		},
+		Lines: reportLines,
+		Totals: BudgetReportTotalsDTO{
+			AllocationAmount:          moneyString(totalAllocation),
+			ActualAmount:              moneyString(totalActual),
+			RemainingAmount:           moneyString(totalAllocation - totalActual),
+			UncategorizedActualAmount: moneyString(float64(uncategorized)),
+		},
+	}, nil
+}
+
 func validateBudgetLineName(name string) (string, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
@@ -494,6 +624,14 @@ func (s *Service) budgetLineDTOWithCategories(ctx context.Context, line sqlc.Bud
 		})
 	}
 	return budgetLineDTO(line, categories), nil
+}
+
+func moneyString(value float64) string {
+	return fmt.Sprintf("%.2f", value)
+}
+
+func parseMoney(value string) (float64, error) {
+	return strconv.ParseFloat(strings.TrimSpace(value), 64)
 }
 
 func parseBudgetNumeric(value string) (pgtype.Numeric, error) {

--- a/internal/app/budgets.go
+++ b/internal/app/budgets.go
@@ -40,6 +40,24 @@ type BudgetLineDTO struct {
 	Categories       []CategoryRefDTO `json:"categories"`
 }
 
+type CreateBudgetLineRequest struct {
+	BudgetID         int64    `json:"budgetId"`
+	Name             string   `json:"name"`
+	AllocationAmount string   `json:"allocationAmount"`
+	CategoryIDs      []int64  `json:"categoryIds,omitempty"`
+	CategoryCodes    []string `json:"categoryCodes,omitempty"`
+	SortOrder        *int32   `json:"sortOrder,omitempty"`
+}
+
+type UpdateBudgetLineRequest struct {
+	LineID           int64     `json:"lineId"`
+	Name             *string   `json:"name,omitempty"`
+	AllocationAmount *string   `json:"allocationAmount,omitempty"`
+	CategoryIDs      *[]int64  `json:"categoryIds,omitempty"`
+	CategoryCodes    *[]string `json:"categoryCodes,omitempty"`
+	SortOrder        *int32    `json:"sortOrder,omitempty"`
+}
+
 func (s *Service) GetMonthlyBudget(ctx context.Context, req GetMonthlyBudgetRequest) (BudgetDTO, error) {
 	if err := validateBudgetOwner(req.HouseholdID, req.UserID); err != nil {
 		return BudgetDTO{}, err
@@ -273,6 +291,209 @@ func budgetLineDTO(line sqlc.BudgetLine, categories []CategoryRefDTO) BudgetLine
 		SortOrder:        line.SortOrder,
 		Categories:       categories,
 	}
+}
+
+func (s *Service) CreateBudgetLine(ctx context.Context, req CreateBudgetLineRequest) (BudgetLineDTO, error) {
+	if req.BudgetID == 0 {
+		return BudgetLineDTO{}, NewError(CodeValidationError, "budget id is required", nil)
+	}
+	if _, err := s.repo.GetBudgetById(ctx, req.BudgetID); err != nil {
+		return BudgetLineDTO{}, mapBudgetError(err)
+	}
+	name, err := validateBudgetLineName(req.Name)
+	if err != nil {
+		return BudgetLineDTO{}, err
+	}
+	allocation, err := parseBudgetNumeric(req.AllocationAmount)
+	if err != nil {
+		return BudgetLineDTO{}, err
+	}
+	categoryIDs, err := s.resolveBudgetCategoryIDs(ctx, req.CategoryIDs, req.CategoryCodes)
+	if err != nil {
+		return BudgetLineDTO{}, err
+	}
+	if err := s.validateBudgetCategoryAvailability(ctx, req.BudgetID, 0, categoryIDs); err != nil {
+		return BudgetLineDTO{}, err
+	}
+	sortOrder := req.SortOrder
+	if sortOrder == nil {
+		maxSortOrder, err := s.repo.GetMaxBudgetLineSortOrder(ctx, req.BudgetID)
+		if err != nil {
+			return BudgetLineDTO{}, mapBudgetError(err)
+		}
+		nextSortOrder := maxSortOrder + 1
+		sortOrder = &nextSortOrder
+	}
+	line, err := s.repo.CreateBudgetLine(ctx, sqlc.CreateBudgetLineParams{
+		BudgetID:         req.BudgetID,
+		Name:             name,
+		AllocationAmount: allocation,
+		SortOrder:        *sortOrder,
+	})
+	if err != nil {
+		return BudgetLineDTO{}, mapBudgetError(err)
+	}
+	if err := s.replaceBudgetLineCategories(ctx, req.BudgetID, line.ID, categoryIDs); err != nil {
+		return BudgetLineDTO{}, err
+	}
+	return s.budgetLineDTOWithCategories(ctx, line)
+}
+
+func (s *Service) UpdateBudgetLine(ctx context.Context, req UpdateBudgetLineRequest) (BudgetLineDTO, error) {
+	if req.LineID == 0 {
+		return BudgetLineDTO{}, NewError(CodeValidationError, "budget line id is required", nil)
+	}
+	existing, err := s.repo.GetBudgetLineById(ctx, req.LineID)
+	if err != nil {
+		return BudgetLineDTO{}, mapBudgetError(err)
+	}
+	params := sqlc.UpdateBudgetLineParams{ID: req.LineID}
+	if req.Name != nil {
+		name, err := validateBudgetLineName(*req.Name)
+		if err != nil {
+			return BudgetLineDTO{}, err
+		}
+		params.SetName = true
+		params.Name = name
+	}
+	if req.AllocationAmount != nil {
+		allocation, err := parseBudgetNumeric(*req.AllocationAmount)
+		if err != nil {
+			return BudgetLineDTO{}, err
+		}
+		params.SetAllocationAmount = true
+		params.AllocationAmount = allocation
+	}
+	if req.SortOrder != nil {
+		params.SetSortOrder = true
+		params.SortOrder = *req.SortOrder
+	}
+	line, err := s.repo.UpdateBudgetLine(ctx, params)
+	if err != nil {
+		return BudgetLineDTO{}, mapBudgetError(err)
+	}
+	if req.CategoryIDs != nil || req.CategoryCodes != nil {
+		categoryIDs := []int64(nil)
+		categoryCodes := []string(nil)
+		if req.CategoryIDs != nil {
+			categoryIDs = *req.CategoryIDs
+		}
+		if req.CategoryCodes != nil {
+			categoryCodes = *req.CategoryCodes
+		}
+		resolvedCategoryIDs, err := s.resolveBudgetCategoryIDs(ctx, categoryIDs, categoryCodes)
+		if err != nil {
+			return BudgetLineDTO{}, err
+		}
+		if err := s.validateBudgetCategoryAvailability(ctx, existing.BudgetID, existing.ID, resolvedCategoryIDs); err != nil {
+			return BudgetLineDTO{}, err
+		}
+		if err := s.replaceBudgetLineCategories(ctx, existing.BudgetID, existing.ID, resolvedCategoryIDs); err != nil {
+			return BudgetLineDTO{}, err
+		}
+	}
+	return s.budgetLineDTOWithCategories(ctx, line)
+}
+
+func (s *Service) DeleteBudgetLine(ctx context.Context, lineID int64) error {
+	if lineID == 0 {
+		return NewError(CodeValidationError, "budget line id is required", nil)
+	}
+	if err := s.repo.DeleteBudgetLine(ctx, lineID); err != nil {
+		return mapBudgetError(err)
+	}
+	return nil
+}
+
+func validateBudgetLineName(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", NewError(CodeValidationError, "budget line name is required", nil)
+	}
+	return name, nil
+}
+
+func (s *Service) resolveBudgetCategoryIDs(ctx context.Context, ids []int64, codes []string) ([]int64, error) {
+	seen := make(map[int64]struct{}, len(ids)+len(codes))
+	resolved := make([]int64, 0, len(ids)+len(codes))
+	for _, id := range ids {
+		category, err := s.repo.GetActiveCategoryById(ctx, id)
+		if err != nil {
+			return nil, mapCategoryError(err)
+		}
+		if _, ok := seen[category.ID]; ok {
+			continue
+		}
+		seen[category.ID] = struct{}{}
+		resolved = append(resolved, category.ID)
+	}
+	for _, code := range codes {
+		category, err := s.repo.GetActiveCategoryByCode(ctx, strings.TrimSpace(code))
+		if err != nil {
+			return nil, mapCategoryError(err)
+		}
+		if _, ok := seen[category.ID]; ok {
+			continue
+		}
+		seen[category.ID] = struct{}{}
+		resolved = append(resolved, category.ID)
+	}
+	return resolved, nil
+}
+
+func (s *Service) validateBudgetCategoryAvailability(ctx context.Context, budgetID, currentLineID int64, categoryIDs []int64) error {
+	existingMappings, err := s.repo.ListBudgetLineCategories(ctx, budgetID)
+	if err != nil {
+		return mapBudgetError(err)
+	}
+	wanted := make(map[int64]struct{}, len(categoryIDs))
+	for _, categoryID := range categoryIDs {
+		wanted[categoryID] = struct{}{}
+	}
+	for _, mapping := range existingMappings {
+		if mapping.BudgetLineID == currentLineID {
+			continue
+		}
+		if _, ok := wanted[mapping.CategoryID]; ok {
+			return NewError(CodeValidationError, "category already mapped to another budget line", nil)
+		}
+	}
+	return nil
+}
+
+func (s *Service) replaceBudgetLineCategories(ctx context.Context, budgetID, lineID int64, categoryIDs []int64) error {
+	if err := s.repo.DeleteBudgetLineCategories(ctx, lineID); err != nil {
+		return mapBudgetError(err)
+	}
+	for _, categoryID := range categoryIDs {
+		if err := s.repo.CreateBudgetLineCategory(ctx, sqlc.CreateBudgetLineCategoryParams{
+			BudgetID:     budgetID,
+			BudgetLineID: lineID,
+			CategoryID:   categoryID,
+		}); err != nil {
+			return mapBudgetError(err)
+		}
+	}
+	return nil
+}
+
+func (s *Service) budgetLineDTOWithCategories(ctx context.Context, line sqlc.BudgetLine) (BudgetLineDTO, error) {
+	categoryRows, err := s.repo.ListBudgetLineCategories(ctx, line.BudgetID)
+	if err != nil {
+		return BudgetLineDTO{}, mapBudgetError(err)
+	}
+	categories := make([]CategoryRefDTO, 0)
+	for _, row := range categoryRows {
+		if row.BudgetLineID != line.ID {
+			continue
+		}
+		categories = append(categories, CategoryRefDTO{
+			ID:   row.CategoryID,
+			Code: row.CategoryCode,
+			Name: row.CategoryName,
+		})
+	}
+	return budgetLineDTO(line, categories), nil
 }
 
 func parseBudgetNumeric(value string) (pgtype.Numeric, error) {

--- a/internal/app/budgets.go
+++ b/internal/app/budgets.go
@@ -110,30 +110,53 @@ func (s *Service) createMonthlyBudget(ctx context.Context, householdID, userID *
 		return sqlc.Budget{}, err
 	}
 
+	if sourceBudgetID == nil {
+		return s.createBudget(ctx, s.repo, householdID, userID, periodStart, periodEnd, nil)
+	}
+	if s.transactor == nil {
+		return sqlc.Budget{}, NewError(CodeDatabaseError, "database error", errors.New("budget copy requires transaction support"))
+	}
+
 	var budget sqlc.Budget
+	err = s.transactor.WithinTx(ctx, func(repo Repository) error {
+		created, err := s.createBudget(ctx, repo, householdID, userID, periodStart, periodEnd, sourceBudgetID)
+		if err != nil {
+			return err
+		}
+		if err := s.copyBudgetLines(ctx, repo, sourceBudget.ID, created.ID); err != nil {
+			return err
+		}
+		budget = created
+		return nil
+	})
+	if err != nil {
+		return sqlc.Budget{}, err
+	}
+	return budget, nil
+}
+
+func (s *Service) createBudget(ctx context.Context, repo Repository, householdID, userID *int64, periodStart, periodEnd pgtype.Date, sourceBudgetID *int64) (sqlc.Budget, error) {
 	if householdID != nil {
-		budget, err = s.repo.CreateHouseholdBudget(ctx, sqlc.CreateHouseholdBudgetParams{
+		budget, err := repo.CreateHouseholdBudget(ctx, sqlc.CreateHouseholdBudgetParams{
 			HouseholdID:    *householdID,
 			PeriodStart:    periodStart,
 			PeriodEnd:      periodEnd,
 			SourceBudgetID: sourceBudgetID,
 		})
-	} else {
-		budget, err = s.repo.CreateUserBudget(ctx, sqlc.CreateUserBudgetParams{
-			UserID:         *userID,
-			PeriodStart:    periodStart,
-			PeriodEnd:      periodEnd,
-			SourceBudgetID: sourceBudgetID,
-		})
-	}
-	if err != nil {
-		return sqlc.Budget{}, mapBudgetError(err)
+		if err != nil {
+			return sqlc.Budget{}, mapBudgetError(err)
+		}
+		return budget, nil
 	}
 
-	if sourceBudgetID != nil {
-		if err := s.copyBudgetLines(ctx, sourceBudget.ID, budget.ID); err != nil {
-			return sqlc.Budget{}, err
-		}
+	budget, err := repo.CreateUserBudget(ctx, sqlc.CreateUserBudgetParams{
+		UserID:         *userID,
+		PeriodStart:    periodStart,
+		PeriodEnd:      periodEnd,
+		SourceBudgetID: sourceBudgetID,
+	})
+	if err != nil {
+		return sqlc.Budget{}, mapBudgetError(err)
 	}
 	return budget, nil
 }
@@ -164,12 +187,12 @@ func (s *Service) latestPriorBudget(ctx context.Context, householdID, userID *in
 	return budget, &sourceBudgetID, nil
 }
 
-func (s *Service) copyBudgetLines(ctx context.Context, sourceBudgetID, targetBudgetID int64) error {
-	sourceLines, err := s.repo.ListBudgetLines(ctx, sourceBudgetID)
+func (s *Service) copyBudgetLines(ctx context.Context, repo Repository, sourceBudgetID, targetBudgetID int64) error {
+	sourceLines, err := repo.ListBudgetLines(ctx, sourceBudgetID)
 	if err != nil {
 		return mapBudgetError(err)
 	}
-	sourceMappings, err := s.repo.ListBudgetLineCategories(ctx, sourceBudgetID)
+	sourceMappings, err := repo.ListBudgetLineCategories(ctx, sourceBudgetID)
 	if err != nil {
 		return mapBudgetError(err)
 	}
@@ -180,7 +203,7 @@ func (s *Service) copyBudgetLines(ctx context.Context, sourceBudgetID, targetBud
 	}
 
 	for _, sourceLine := range sourceLines {
-		targetLine, err := s.repo.CreateBudgetLine(ctx, sqlc.CreateBudgetLineParams{
+		targetLine, err := repo.CreateBudgetLine(ctx, sqlc.CreateBudgetLineParams{
 			BudgetID:         targetBudgetID,
 			Name:             sourceLine.Name,
 			AllocationAmount: sourceLine.AllocationAmount,
@@ -190,7 +213,7 @@ func (s *Service) copyBudgetLines(ctx context.Context, sourceBudgetID, targetBud
 			return mapBudgetError(err)
 		}
 		for _, mapping := range mappingsByLineID[sourceLine.ID] {
-			err := s.repo.CreateBudgetLineCategory(ctx, sqlc.CreateBudgetLineCategoryParams{
+			err := repo.CreateBudgetLineCategory(ctx, sqlc.CreateBudgetLineCategoryParams{
 				BudgetID:     targetBudgetID,
 				BudgetLineID: targetLine.ID,
 				CategoryID:   mapping.CategoryID,

--- a/internal/app/budgets.go
+++ b/internal/app/budgets.go
@@ -343,7 +343,7 @@ func (s *Service) CreateBudgetLine(ctx context.Context, req CreateBudgetLineRequ
 	if err != nil {
 		return BudgetLineDTO{}, err
 	}
-	categoryIDs, err := s.resolveBudgetCategoryIDs(ctx, req.CategoryIDs, req.CategoryCodes)
+	categoryIDs, err := s.resolveLineCategoryIDs(ctx, req.CategoryIDs, req.CategoryCodes)
 	if err != nil {
 		return BudgetLineDTO{}, err
 	}
@@ -416,7 +416,7 @@ func (s *Service) UpdateBudgetLine(ctx context.Context, req UpdateBudgetLineRequ
 		if req.CategoryCodes != nil {
 			categoryCodes = *req.CategoryCodes
 		}
-		resolvedCategoryIDs, err := s.resolveBudgetCategoryIDs(ctx, categoryIDs, categoryCodes)
+		resolvedCategoryIDs, err := s.resolveLineCategoryIDs(ctx, categoryIDs, categoryCodes)
 		if err != nil {
 			return BudgetLineDTO{}, err
 		}
@@ -543,7 +543,7 @@ func validateBudgetLineName(name string) (string, error) {
 	return name, nil
 }
 
-func (s *Service) resolveBudgetCategoryIDs(ctx context.Context, ids []int64, codes []string) ([]int64, error) {
+func (s *Service) resolveLineCategoryIDs(ctx context.Context, ids []int64, codes []string) ([]int64, error) {
 	seen := make(map[int64]struct{}, len(ids)+len(codes))
 	resolved := make([]int64, 0, len(ids)+len(codes))
 	for _, id := range ids {

--- a/internal/app/budgets.go
+++ b/internal/app/budgets.go
@@ -65,7 +65,7 @@ func (s *Service) GetMonthlyBudget(ctx context.Context, req GetMonthlyBudgetRequ
 
 	budget, err = s.createMonthlyBudget(ctx, req.HouseholdID, req.UserID, periodStart, periodEnd)
 	if err != nil {
-		return BudgetDTO{}, mapBudgetError(err)
+		return BudgetDTO{}, err
 	}
 	return s.budgetDTO(ctx, budget)
 }
@@ -105,20 +105,102 @@ func (s *Service) findBudgetByPeriod(ctx context.Context, householdID, userID *i
 }
 
 func (s *Service) createMonthlyBudget(ctx context.Context, householdID, userID *int64, periodStart, periodEnd pgtype.Date) (sqlc.Budget, error) {
+	sourceBudget, sourceBudgetID, err := s.latestPriorBudget(ctx, householdID, userID, periodStart)
+	if err != nil {
+		return sqlc.Budget{}, err
+	}
+
+	var budget sqlc.Budget
 	if householdID != nil {
-		return s.repo.CreateHouseholdBudget(ctx, sqlc.CreateHouseholdBudgetParams{
+		budget, err = s.repo.CreateHouseholdBudget(ctx, sqlc.CreateHouseholdBudgetParams{
 			HouseholdID:    *householdID,
 			PeriodStart:    periodStart,
 			PeriodEnd:      periodEnd,
-			SourceBudgetID: nil,
+			SourceBudgetID: sourceBudgetID,
+		})
+	} else {
+		budget, err = s.repo.CreateUserBudget(ctx, sqlc.CreateUserBudgetParams{
+			UserID:         *userID,
+			PeriodStart:    periodStart,
+			PeriodEnd:      periodEnd,
+			SourceBudgetID: sourceBudgetID,
 		})
 	}
-	return s.repo.CreateUserBudget(ctx, sqlc.CreateUserBudgetParams{
-		UserID:         *userID,
-		PeriodStart:    periodStart,
-		PeriodEnd:      periodEnd,
-		SourceBudgetID: nil,
-	})
+	if err != nil {
+		return sqlc.Budget{}, mapBudgetError(err)
+	}
+
+	if sourceBudgetID != nil {
+		if err := s.copyBudgetLines(ctx, sourceBudget.ID, budget.ID); err != nil {
+			return sqlc.Budget{}, err
+		}
+	}
+	return budget, nil
+}
+
+func (s *Service) latestPriorBudget(ctx context.Context, householdID, userID *int64, periodStart pgtype.Date) (sqlc.Budget, *int64, error) {
+	var (
+		budget sqlc.Budget
+		err    error
+	)
+	if householdID != nil {
+		budget, err = s.repo.GetLatestPriorHouseholdBudget(ctx, sqlc.GetLatestPriorHouseholdBudgetParams{
+			HouseholdID: *householdID,
+			PeriodStart: periodStart,
+		})
+	} else {
+		budget, err = s.repo.GetLatestPriorUserBudget(ctx, sqlc.GetLatestPriorUserBudgetParams{
+			UserID:      *userID,
+			PeriodStart: periodStart,
+		})
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return sqlc.Budget{}, nil, nil
+	}
+	if err != nil {
+		return sqlc.Budget{}, nil, mapBudgetError(err)
+	}
+	sourceBudgetID := budget.ID
+	return budget, &sourceBudgetID, nil
+}
+
+func (s *Service) copyBudgetLines(ctx context.Context, sourceBudgetID, targetBudgetID int64) error {
+	sourceLines, err := s.repo.ListBudgetLines(ctx, sourceBudgetID)
+	if err != nil {
+		return mapBudgetError(err)
+	}
+	sourceMappings, err := s.repo.ListBudgetLineCategories(ctx, sourceBudgetID)
+	if err != nil {
+		return mapBudgetError(err)
+	}
+
+	mappingsByLineID := make(map[int64][]sqlc.ListBudgetLineCategoriesRow)
+	for _, mapping := range sourceMappings {
+		mappingsByLineID[mapping.BudgetLineID] = append(mappingsByLineID[mapping.BudgetLineID], mapping)
+	}
+
+	for _, sourceLine := range sourceLines {
+		targetLine, err := s.repo.CreateBudgetLine(ctx, sqlc.CreateBudgetLineParams{
+			BudgetID:         targetBudgetID,
+			Name:             sourceLine.Name,
+			AllocationAmount: sourceLine.AllocationAmount,
+			SortOrder:        sourceLine.SortOrder,
+		})
+		if err != nil {
+			return mapBudgetError(err)
+		}
+		for _, mapping := range mappingsByLineID[sourceLine.ID] {
+			err := s.repo.CreateBudgetLineCategory(ctx, sqlc.CreateBudgetLineCategoryParams{
+				BudgetID:     targetBudgetID,
+				BudgetLineID: targetLine.ID,
+				CategoryID:   mapping.CategoryID,
+			})
+			if err != nil {
+				return mapBudgetError(err)
+			}
+		}
+	}
+	return nil
 }
 
 func (s *Service) budgetDTO(ctx context.Context, budget sqlc.Budget) (BudgetDTO, error) {

--- a/internal/app/budgets.go
+++ b/internal/app/budgets.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 	"time"
@@ -79,6 +78,9 @@ func validateBudgetOwner(householdID, userID *int64) error {
 }
 
 func monthlyBudgetPeriod(year int, month int) (time.Time, time.Time, error) {
+	if year < 1 {
+		return time.Time{}, time.Time{}, NewError(CodeValidationError, "year must be greater than 0", nil)
+	}
 	if month < 1 || month > 12 {
 		return time.Time{}, time.Time{}, NewError(CodeValidationError, "month must be between 1 and 12", nil)
 	}
@@ -191,43 +193,36 @@ func parseBudgetNumeric(value string) (pgtype.Numeric, error) {
 			return pgtype.Numeric{}, NewError(CodeValidationError, "allocation amount supports at most two decimal places", nil)
 		}
 	}
-	digits := parts[0] + fraction
-	for _, char := range digits {
+	for _, char := range parts[0] + fraction {
 		if char < '0' || char > '9' {
 			return pgtype.Numeric{}, NewError(CodeValidationError, "allocation amount must be a decimal string", nil)
 		}
 	}
 
+	for len(fraction) < 2 {
+		fraction += "0"
+	}
+	digits := parts[0] + fraction
 	intValue := new(big.Int)
 	if _, ok := intValue.SetString(digits, 10); !ok {
-		return pgtype.Numeric{}, fmt.Errorf("parse allocation amount %q", value)
+		return pgtype.Numeric{}, NewError(CodeValidationError, "allocation amount must be a decimal string", nil)
 	}
-	return pgtype.Numeric{Int: intValue, Exp: -int32(len(fraction)), Valid: true}, nil
+	return pgtype.Numeric{Int: intValue, Exp: -2, Valid: true}, nil
 }
 
 func budgetNumericString(value pgtype.Numeric) string {
 	if !value.Valid || value.Int == nil {
-		return "0"
-	}
-	digits := value.Int.String()
-	if value.Exp >= 0 {
-		return digits + strings.Repeat("0", int(value.Exp))
+		return "0.00"
 	}
 
-	scale := int(-value.Exp)
-	negative := strings.HasPrefix(digits, "-")
-	if negative {
-		digits = strings.TrimPrefix(digits, "-")
+	ratio := new(big.Rat).SetInt(value.Int)
+	if value.Exp > 0 {
+		ratio.Mul(ratio, new(big.Rat).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(value.Exp)), nil)))
 	}
-	for len(digits) <= scale {
-		digits = "0" + digits
+	if value.Exp < 0 {
+		ratio.Quo(ratio, new(big.Rat).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(-value.Exp)), nil)))
 	}
-	point := len(digits) - scale
-	result := digits[:point] + "." + digits[point:]
-	if negative {
-		result = "-" + result
-	}
-	return result
+	return ratio.FloatString(2)
 }
 
 func mapBudgetError(err error) error {

--- a/internal/app/budgets.go
+++ b/internal/app/budgets.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"math/big"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"rdmm404/voltr-finance/internal/database/sqlc"
@@ -118,6 +118,12 @@ func (s *Service) GetMonthlyBudget(ctx context.Context, req GetMonthlyBudgetRequ
 
 	budget, err = s.createMonthlyBudget(ctx, req.HouseholdID, req.UserID, periodStart, periodEnd)
 	if err != nil {
+		if isUniqueViolation(err) {
+			budget, findErr := s.findBudgetByPeriod(ctx, req.HouseholdID, req.UserID, periodStart, periodEnd)
+			if findErr == nil {
+				return s.budgetDTO(ctx, budget)
+			}
+		}
 		return BudgetDTO{}, err
 	}
 	return s.budgetDTO(ctx, budget)
@@ -315,9 +321,7 @@ func (s *Service) budgetDTO(ctx context.Context, budget sqlc.Budget) (BudgetDTO,
 }
 
 func budgetLineDTO(line sqlc.BudgetLine, categories []CategoryRefDTO) BudgetLineDTO {
-	if categories == nil {
-		categories = []CategoryRefDTO{}
-	}
+	categories = normalizeCategories(categories)
 	return BudgetLineDTO{
 		ID:               line.ID,
 		BudgetID:         line.BudgetID,
@@ -328,12 +332,16 @@ func budgetLineDTO(line sqlc.BudgetLine, categories []CategoryRefDTO) BudgetLine
 	}
 }
 
+func normalizeCategories(categories []CategoryRefDTO) []CategoryRefDTO {
+	if categories == nil {
+		return []CategoryRefDTO{}
+	}
+	return categories
+}
+
 func (s *Service) CreateBudgetLine(ctx context.Context, req CreateBudgetLineRequest) (BudgetLineDTO, error) {
 	if req.BudgetID == 0 {
 		return BudgetLineDTO{}, NewError(CodeValidationError, "budget id is required", nil)
-	}
-	if _, err := s.repo.GetBudgetById(ctx, req.BudgetID); err != nil {
-		return BudgetLineDTO{}, mapBudgetError(err)
 	}
 	name, err := validateBudgetLineName(req.Name)
 	if err != nil {
@@ -343,32 +351,47 @@ func (s *Service) CreateBudgetLine(ctx context.Context, req CreateBudgetLineRequ
 	if err != nil {
 		return BudgetLineDTO{}, err
 	}
-	categoryIDs, err := s.resolveLineCategoryIDs(ctx, req.CategoryIDs, req.CategoryCodes)
-	if err != nil {
-		return BudgetLineDTO{}, err
+	if s.transactor == nil {
+		return BudgetLineDTO{}, NewError(CodeDatabaseError, "database error", errors.New("budget line changes require transaction support"))
 	}
-	if err := s.validateBudgetCategoryAvailability(ctx, req.BudgetID, 0, categoryIDs); err != nil {
-		return BudgetLineDTO{}, err
-	}
-	sortOrder := req.SortOrder
-	if sortOrder == nil {
-		maxSortOrder, err := s.repo.GetMaxBudgetLineSortOrder(ctx, req.BudgetID)
-		if err != nil {
-			return BudgetLineDTO{}, mapBudgetError(err)
+
+	var line sqlc.BudgetLine
+	err = s.transactor.WithinTx(ctx, func(repo Repository) error {
+		if _, err := repo.GetBudgetById(ctx, req.BudgetID); err != nil {
+			return mapBudgetError(err)
 		}
-		nextSortOrder := maxSortOrder + 1
-		sortOrder = &nextSortOrder
-	}
-	line, err := s.repo.CreateBudgetLine(ctx, sqlc.CreateBudgetLineParams{
-		BudgetID:         req.BudgetID,
-		Name:             name,
-		AllocationAmount: allocation,
-		SortOrder:        *sortOrder,
+		categoryIDs, err := s.resolveLineCategoryIDs(ctx, repo, req.CategoryIDs, req.CategoryCodes)
+		if err != nil {
+			return err
+		}
+		if err := s.validateBudgetCategoryAvailability(ctx, repo, req.BudgetID, 0, categoryIDs); err != nil {
+			return err
+		}
+		sortOrder := req.SortOrder
+		if sortOrder == nil {
+			maxSortOrder, err := repo.GetMaxBudgetLineSortOrder(ctx, req.BudgetID)
+			if err != nil {
+				return mapBudgetError(err)
+			}
+			nextSortOrder := maxSortOrder + 1
+			sortOrder = &nextSortOrder
+		}
+		created, err := repo.CreateBudgetLine(ctx, sqlc.CreateBudgetLineParams{
+			BudgetID:         req.BudgetID,
+			Name:             name,
+			AllocationAmount: allocation,
+			SortOrder:        *sortOrder,
+		})
+		if err != nil {
+			return mapBudgetError(err)
+		}
+		if err := s.replaceBudgetLineCategories(ctx, repo, req.BudgetID, created.ID, categoryIDs); err != nil {
+			return err
+		}
+		line = created
+		return nil
 	})
 	if err != nil {
-		return BudgetLineDTO{}, mapBudgetError(err)
-	}
-	if err := s.replaceBudgetLineCategories(ctx, req.BudgetID, line.ID, categoryIDs); err != nil {
 		return BudgetLineDTO{}, err
 	}
 	return s.budgetLineDTOWithCategories(ctx, line)
@@ -377,10 +400,6 @@ func (s *Service) CreateBudgetLine(ctx context.Context, req CreateBudgetLineRequ
 func (s *Service) UpdateBudgetLine(ctx context.Context, req UpdateBudgetLineRequest) (BudgetLineDTO, error) {
 	if req.LineID == 0 {
 		return BudgetLineDTO{}, NewError(CodeValidationError, "budget line id is required", nil)
-	}
-	existing, err := s.repo.GetBudgetLineById(ctx, req.LineID)
-	if err != nil {
-		return BudgetLineDTO{}, mapBudgetError(err)
 	}
 	params := sqlc.UpdateBudgetLineParams{ID: req.LineID}
 	if req.Name != nil {
@@ -403,29 +422,48 @@ func (s *Service) UpdateBudgetLine(ctx context.Context, req UpdateBudgetLineRequ
 		params.SetSortOrder = true
 		params.SortOrder = *req.SortOrder
 	}
-	line, err := s.repo.UpdateBudgetLine(ctx, params)
-	if err != nil {
-		return BudgetLineDTO{}, mapBudgetError(err)
+	if s.transactor == nil {
+		return BudgetLineDTO{}, NewError(CodeDatabaseError, "database error", errors.New("budget line changes require transaction support"))
 	}
-	if req.CategoryIDs != nil || req.CategoryCodes != nil {
-		categoryIDs := []int64(nil)
-		categoryCodes := []string(nil)
-		if req.CategoryIDs != nil {
-			categoryIDs = *req.CategoryIDs
-		}
-		if req.CategoryCodes != nil {
-			categoryCodes = *req.CategoryCodes
-		}
-		resolvedCategoryIDs, err := s.resolveLineCategoryIDs(ctx, categoryIDs, categoryCodes)
+
+	var line sqlc.BudgetLine
+	err := s.transactor.WithinTx(ctx, func(repo Repository) error {
+		existing, err := repo.GetBudgetLineById(ctx, req.LineID)
 		if err != nil {
-			return BudgetLineDTO{}, err
+			return mapBudgetError(err)
 		}
-		if err := s.validateBudgetCategoryAvailability(ctx, existing.BudgetID, existing.ID, resolvedCategoryIDs); err != nil {
-			return BudgetLineDTO{}, err
+		var resolvedCategoryIDs []int64
+		if req.CategoryIDs != nil || req.CategoryCodes != nil {
+			categoryIDs := []int64(nil)
+			categoryCodes := []string(nil)
+			if req.CategoryIDs != nil {
+				categoryIDs = *req.CategoryIDs
+			}
+			if req.CategoryCodes != nil {
+				categoryCodes = *req.CategoryCodes
+			}
+			resolvedCategoryIDs, err = s.resolveLineCategoryIDs(ctx, repo, categoryIDs, categoryCodes)
+			if err != nil {
+				return err
+			}
+			if err := s.validateBudgetCategoryAvailability(ctx, repo, existing.BudgetID, existing.ID, resolvedCategoryIDs); err != nil {
+				return err
+			}
 		}
-		if err := s.replaceBudgetLineCategories(ctx, existing.BudgetID, existing.ID, resolvedCategoryIDs); err != nil {
-			return BudgetLineDTO{}, err
+		updated, err := repo.UpdateBudgetLine(ctx, params)
+		if err != nil {
+			return mapBudgetError(err)
 		}
+		if req.CategoryIDs != nil || req.CategoryCodes != nil {
+			if err := s.replaceBudgetLineCategories(ctx, repo, existing.BudgetID, existing.ID, resolvedCategoryIDs); err != nil {
+				return err
+			}
+		}
+		line = updated
+		return nil
+	})
+	if err != nil {
+		return BudgetLineDTO{}, err
 	}
 	return s.budgetLineDTOWithCategories(ctx, line)
 }
@@ -448,7 +486,7 @@ func (s *Service) GetBudgetReport(ctx context.Context, budgetID int64) (BudgetRe
 	if err != nil {
 		return BudgetReportDTO{}, mapBudgetError(err)
 	}
-	lines, err := s.repo.ListBudgetLines(ctx, budgetID)
+	lines, err := s.repo.ListBudgetReportLines(ctx, budgetID)
 	if err != nil {
 		return BudgetReportDTO{}, mapBudgetError(err)
 	}
@@ -456,65 +494,51 @@ func (s *Service) GetBudgetReport(ctx context.Context, budgetID int64) (BudgetRe
 	if err != nil {
 		return BudgetReportDTO{}, mapBudgetError(err)
 	}
-	actualRows, err := s.repo.ListBudgetTransactions(ctx, sqlc.ListBudgetTransactionsParams{
-		PeriodStart: budget.PeriodStart,
-		PeriodEnd:   budget.PeriodEnd,
-		HouseholdID: budget.HouseholdID,
-		UserID:      budget.UserID,
-	})
-	if err != nil {
-		return BudgetReportDTO{}, mapBudgetError(err)
-	}
-	uncategorized, err := s.repo.SumUncategorizedBudgetTransactions(ctx, sqlc.SumUncategorizedBudgetTransactionsParams{
-		PeriodStart: budget.PeriodStart,
-		PeriodEnd:   budget.PeriodEnd,
-		HouseholdID: budget.HouseholdID,
-		UserID:      budget.UserID,
-	})
+	uncategorized, err := s.repo.SumUncategorizedBudgetTransactions(ctx, budgetID)
 	if err != nil {
 		return BudgetReportDTO{}, mapBudgetError(err)
 	}
 
-	actualByCategory := make(map[int64]float64, len(actualRows))
-	for _, row := range actualRows {
-		actualByCategory[row.CategoryID] = float64(row.ActualAmount)
-	}
 	categoriesByLine := make(map[int64][]CategoryRefDTO)
-	categoryIDsByLine := make(map[int64][]int64)
 	for _, row := range mappings {
 		categoriesByLine[row.BudgetLineID] = append(categoriesByLine[row.BudgetLineID], CategoryRefDTO{
 			ID:   row.CategoryID,
 			Code: row.CategoryCode,
 			Name: row.CategoryName,
 		})
-		categoryIDsByLine[row.BudgetLineID] = append(categoryIDsByLine[row.BudgetLineID], row.CategoryID)
 	}
 
 	reportLines := make([]BudgetReportLineDTO, 0, len(lines))
-	totalAllocation := 0.0
-	totalActual := 0.0
+	totalAllocation := big.NewInt(0)
+	totalActual := big.NewInt(0)
 	for _, line := range lines {
-		allocation, err := parseMoney(budgetNumericString(line.AllocationAmount))
+		allocationCents, err := numericCents(line.AllocationAmount)
 		if err != nil {
 			return BudgetReportDTO{}, NewError(CodeDatabaseError, "invalid budget allocation amount", err)
 		}
-		actual := 0.0
-		for _, categoryID := range categoryIDsByLine[line.ID] {
-			actual += actualByCategory[categoryID]
+		actualCents, err := numericCents(line.ActualAmount)
+		if err != nil {
+			return BudgetReportDTO{}, NewError(CodeDatabaseError, "invalid budget actual amount", err)
 		}
-		totalAllocation += allocation
-		totalActual += actual
+		remainingCents := new(big.Int).Sub(allocationCents, actualCents)
+		totalAllocation.Add(totalAllocation, allocationCents)
+		totalActual.Add(totalActual, actualCents)
 		reportLines = append(reportLines, BudgetReportLineDTO{
 			ID:               line.ID,
 			BudgetID:         line.BudgetID,
 			Name:             line.Name,
-			AllocationAmount: moneyString(allocation),
-			ActualAmount:     moneyString(actual),
-			RemainingAmount:  moneyString(allocation - actual),
+			AllocationAmount: centsString(allocationCents),
+			ActualAmount:     centsString(actualCents),
+			RemainingAmount:  centsString(remainingCents),
 			SortOrder:        line.SortOrder,
-			Categories:       categoriesByLine[line.ID],
+			Categories:       normalizeCategories(categoriesByLine[line.ID]),
 		})
 	}
+	uncategorizedCents, err := numericCents(uncategorized)
+	if err != nil {
+		return BudgetReportDTO{}, NewError(CodeDatabaseError, "invalid uncategorized budget actual amount", err)
+	}
+	totalRemaining := new(big.Int).Sub(totalAllocation, totalActual)
 
 	return BudgetReportDTO{
 		Budget: BudgetSummaryDTO{
@@ -527,10 +551,10 @@ func (s *Service) GetBudgetReport(ctx context.Context, budgetID int64) (BudgetRe
 		},
 		Lines: reportLines,
 		Totals: BudgetReportTotalsDTO{
-			AllocationAmount:          moneyString(totalAllocation),
-			ActualAmount:              moneyString(totalActual),
-			RemainingAmount:           moneyString(totalAllocation - totalActual),
-			UncategorizedActualAmount: moneyString(float64(uncategorized)),
+			AllocationAmount:          centsString(totalAllocation),
+			ActualAmount:              centsString(totalActual),
+			RemainingAmount:           centsString(totalRemaining),
+			UncategorizedActualAmount: centsString(uncategorizedCents),
 		},
 	}, nil
 }
@@ -543,11 +567,11 @@ func validateBudgetLineName(name string) (string, error) {
 	return name, nil
 }
 
-func (s *Service) resolveLineCategoryIDs(ctx context.Context, ids []int64, codes []string) ([]int64, error) {
+func (s *Service) resolveLineCategoryIDs(ctx context.Context, repo Repository, ids []int64, codes []string) ([]int64, error) {
 	seen := make(map[int64]struct{}, len(ids)+len(codes))
 	resolved := make([]int64, 0, len(ids)+len(codes))
 	for _, id := range ids {
-		category, err := s.repo.GetActiveCategoryById(ctx, id)
+		category, err := repo.GetActiveCategoryById(ctx, id)
 		if err != nil {
 			return nil, mapCategoryError(err)
 		}
@@ -558,7 +582,7 @@ func (s *Service) resolveLineCategoryIDs(ctx context.Context, ids []int64, codes
 		resolved = append(resolved, category.ID)
 	}
 	for _, code := range codes {
-		category, err := s.repo.GetActiveCategoryByCode(ctx, strings.TrimSpace(code))
+		category, err := repo.GetActiveCategoryByCode(ctx, strings.TrimSpace(code))
 		if err != nil {
 			return nil, mapCategoryError(err)
 		}
@@ -571,8 +595,8 @@ func (s *Service) resolveLineCategoryIDs(ctx context.Context, ids []int64, codes
 	return resolved, nil
 }
 
-func (s *Service) validateBudgetCategoryAvailability(ctx context.Context, budgetID, currentLineID int64, categoryIDs []int64) error {
-	existingMappings, err := s.repo.ListBudgetLineCategories(ctx, budgetID)
+func (s *Service) validateBudgetCategoryAvailability(ctx context.Context, repo Repository, budgetID, currentLineID int64, categoryIDs []int64) error {
+	existingMappings, err := repo.ListBudgetLineCategories(ctx, budgetID)
 	if err != nil {
 		return mapBudgetError(err)
 	}
@@ -591,12 +615,12 @@ func (s *Service) validateBudgetCategoryAvailability(ctx context.Context, budget
 	return nil
 }
 
-func (s *Service) replaceBudgetLineCategories(ctx context.Context, budgetID, lineID int64, categoryIDs []int64) error {
-	if err := s.repo.DeleteBudgetLineCategories(ctx, lineID); err != nil {
+func (s *Service) replaceBudgetLineCategories(ctx context.Context, repo Repository, budgetID, lineID int64, categoryIDs []int64) error {
+	if err := repo.DeleteBudgetLineCategories(ctx, lineID); err != nil {
 		return mapBudgetError(err)
 	}
 	for _, categoryID := range categoryIDs {
-		if err := s.repo.CreateBudgetLineCategory(ctx, sqlc.CreateBudgetLineCategoryParams{
+		if err := repo.CreateBudgetLineCategory(ctx, sqlc.CreateBudgetLineCategoryParams{
 			BudgetID:     budgetID,
 			BudgetLineID: lineID,
 			CategoryID:   categoryID,
@@ -626,12 +650,43 @@ func (s *Service) budgetLineDTOWithCategories(ctx context.Context, line sqlc.Bud
 	return budgetLineDTO(line, categories), nil
 }
 
-func moneyString(value float64) string {
-	return fmt.Sprintf("%.2f", value)
+func numericCents(value pgtype.Numeric) (*big.Int, error) {
+	if !value.Valid || value.Int == nil {
+		return big.NewInt(0), nil
+	}
+	ratio := new(big.Rat).SetInt(value.Int)
+	if value.Exp > 0 {
+		ratio.Mul(ratio, new(big.Rat).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(value.Exp)), nil)))
+	}
+	if value.Exp < 0 {
+		ratio.Quo(ratio, new(big.Rat).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(-value.Exp)), nil)))
+	}
+	ratio.Mul(ratio, big.NewRat(100, 1))
+	if !ratio.IsInt() {
+		return nil, errors.New("amount has more than two decimal places")
+	}
+	return new(big.Int).Set(ratio.Num()), nil
 }
 
-func parseMoney(value string) (float64, error) {
-	return strconv.ParseFloat(strings.TrimSpace(value), 64)
+func centsString(cents *big.Int) string {
+	if cents == nil {
+		return "0.00"
+	}
+	value := new(big.Int).Set(cents)
+	sign := ""
+	if value.Sign() < 0 {
+		sign = "-"
+		value.Abs(value)
+	}
+	dollars, remainder := new(big.Int).QuoRem(value, big.NewInt(100), new(big.Int))
+	return sign + dollars.String() + "." + fmtTwoDigits(remainder.Int64())
+}
+
+func fmtTwoDigits(value int64) string {
+	if value < 10 {
+		return "0" + strconv.FormatInt(value, 10)
+	}
+	return strconv.FormatInt(value, 10)
 }
 
 func parseBudgetNumeric(value string) (pgtype.Numeric, error) {
@@ -687,6 +742,11 @@ func budgetNumericString(value pgtype.Numeric) string {
 		ratio.Quo(ratio, new(big.Rat).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(-value.Exp)), nil)))
 	}
 	return ratio.FloatString(2)
+}
+
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
 }
 
 func mapBudgetError(err error) error {

--- a/internal/app/budgets_test.go
+++ b/internal/app/budgets_test.go
@@ -38,6 +38,69 @@ func TestMonthlyBudgetPeriodRejectsInvalidMonth(t *testing.T) {
 	}
 }
 
+func TestMonthlyBudgetPeriodRejectsInvalidYear(t *testing.T) {
+	_, _, err := monthlyBudgetPeriod(0, 5)
+
+	if appErr, ok := err.(*AppError); !ok || appErr.Code != CodeValidationError {
+		t.Fatalf("err = %v, want validation error", err)
+	}
+}
+
+func TestParseBudgetNumericNormalizesToCents(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want int64
+	}{
+		{name: "zero", in: "0", want: 0},
+		{name: "whole dollars", in: "1", want: 100},
+		{name: "one decimal place", in: "1.2", want: 120},
+		{name: "two decimal places", in: "1.23", want: 123},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseBudgetNumeric(tt.in)
+			if err != nil {
+				t.Fatalf("parseBudgetNumeric returned error: %v", err)
+			}
+			if !got.Valid || got.Exp != -2 || got.Int == nil || got.Int.Cmp(big.NewInt(tt.want)) != 0 {
+				t.Fatalf("numeric = %+v, want Int=%d Exp=-2 Valid=true", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseBudgetNumericRejectsMoreThanTwoDecimalPlaces(t *testing.T) {
+	_, err := parseBudgetNumeric("1.234")
+
+	if appErr, ok := err.(*AppError); !ok || appErr.Code != CodeValidationError {
+		t.Fatalf("err = %v, want validation error", err)
+	}
+}
+
+func TestBudgetNumericStringFormatsTwoDecimalPlaces(t *testing.T) {
+	tests := []struct {
+		name string
+		in   pgtype.Numeric
+		want string
+	}{
+		{name: "zero", in: pgtype.Numeric{Int: big.NewInt(0), Exp: -2, Valid: true}, want: "0.00"},
+		{name: "whole dollars", in: pgtype.Numeric{Int: big.NewInt(1), Exp: 0, Valid: true}, want: "1.00"},
+		{name: "one decimal place", in: pgtype.Numeric{Int: big.NewInt(12), Exp: -1, Valid: true}, want: "1.20"},
+		{name: "two decimal places", in: pgtype.Numeric{Int: big.NewInt(123), Exp: -2, Valid: true}, want: "1.23"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := budgetNumericString(tt.in)
+			if got != tt.want {
+				t.Fatalf("budgetNumericString = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetMonthlyBudgetRejectsMissingOwner(t *testing.T) {
 	svc := NewService(&fakeRepo{}, &fakeTransactionService{})
 
@@ -85,9 +148,17 @@ func TestGetMonthlyBudgetReturnsExistingHouseholdBudget(t *testing.T) {
 				AllocationAmount: pgtype.Numeric{Int: big.NewInt(12550), Exp: -2, Valid: true},
 				SortOrder:        1,
 			},
+			{
+				ID:               22,
+				BudgetID:         99,
+				Name:             "Other Budget",
+				AllocationAmount: pgtype.Numeric{Int: big.NewInt(99999), Exp: -2, Valid: true},
+				SortOrder:        1,
+			},
 		},
 		budgetLineCategories: []sqlc.ListBudgetLineCategoriesRow{
 			{BudgetID: 11, BudgetLineID: 21, CategoryID: 31, CategoryCode: "groceries", CategoryName: "Groceries"},
+			{BudgetID: 99, BudgetLineID: 22, CategoryID: 32, CategoryCode: "other", CategoryName: "Other"},
 		},
 	}
 	svc := NewService(repo, &fakeTransactionService{})
@@ -110,11 +181,60 @@ func TestGetMonthlyBudgetReturnsExistingHouseholdBudget(t *testing.T) {
 	if repo.lastHouseholdBudgetPeriodStart != start.Time {
 		t.Fatalf("period start passed to repo = %s, want %s", repo.lastHouseholdBudgetPeriodStart, start.Time)
 	}
+	if repo.lastListBudgetLinesBudgetID != 11 || repo.lastListBudgetLineCategoriesBudgetID != 11 {
+		t.Fatalf("list budget ids = %d/%d, want 11/11", repo.lastListBudgetLinesBudgetID, repo.lastListBudgetLineCategoriesBudgetID)
+	}
 	if len(budget.Lines) != 1 || budget.Lines[0].AllocationAmount != "125.50" {
 		t.Fatalf("lines = %+v, want mapped line with allocation amount string", budget.Lines)
 	}
 	if len(budget.Lines[0].Categories) != 1 || budget.Lines[0].Categories[0].Code != "groceries" {
 		t.Fatalf("categories = %+v, want groceries category", budget.Lines[0].Categories)
+	}
+}
+
+func TestGetMonthlyBudgetReturnsExistingUserBudget(t *testing.T) {
+	userID := int64(8)
+	start := pgtype.Date{Time: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC), Valid: true}
+	end := pgtype.Date{Time: time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC), Valid: true}
+	repo := &fakeRepo{
+		userBudgetByPeriod: sqlc.Budget{
+			ID:          12,
+			UserID:      &userID,
+			PeriodStart: start,
+			PeriodEnd:   end,
+		},
+	}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	budget, err := svc.GetMonthlyBudget(context.Background(), GetMonthlyBudgetRequest{
+		UserID: &userID,
+		Year:   2026,
+		Month:  5,
+	})
+
+	if err != nil {
+		t.Fatalf("GetMonthlyBudget returned error: %v", err)
+	}
+	if budget.ID != 12 || budget.UserID == nil || *budget.UserID != userID || budget.HouseholdID != nil {
+		t.Fatalf("budget owner = %+v, want user budget", budget)
+	}
+	if repo.lastUserBudgetPeriodStart != start.Time {
+		t.Fatalf("period start passed to repo = %s, want %s", repo.lastUserBudgetPeriodStart, start.Time)
+	}
+}
+
+func TestGetMonthlyBudgetReturnsValidationErrorWhenMissingWithoutCreate(t *testing.T) {
+	householdID := int64(7)
+	svc := NewService(&fakeRepo{}, &fakeTransactionService{})
+
+	_, err := svc.GetMonthlyBudget(context.Background(), GetMonthlyBudgetRequest{
+		HouseholdID: &householdID,
+		Year:        2026,
+		Month:       5,
+	})
+
+	if appErr, ok := err.(*AppError); !ok || appErr.Code != CodeValidationError {
+		t.Fatalf("err = %v, want validation error", err)
 	}
 }
 
@@ -149,6 +269,37 @@ func TestGetMonthlyBudgetCreatesEmptyHouseholdBudgetWhenMissing(t *testing.T) {
 	}
 	if len(budget.Lines) != 0 {
 		t.Fatalf("lines = %+v, want empty budget", budget.Lines)
+	}
+}
+
+func TestGetMonthlyBudgetCreatesEmptyUserBudgetWhenMissing(t *testing.T) {
+	userID := int64(8)
+	repo := &fakeRepo{}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	budget, err := svc.GetMonthlyBudget(context.Background(), GetMonthlyBudgetRequest{
+		UserID:          &userID,
+		Year:            2026,
+		Month:           5,
+		CreateIfMissing: true,
+	})
+
+	if err != nil {
+		t.Fatalf("GetMonthlyBudget returned error: %v", err)
+	}
+	if budget.ID == 0 || budget.UserID == nil || *budget.UserID != userID {
+		t.Fatalf("budget = %+v, want created user budget", budget)
+	}
+	wantStart := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	wantEnd := time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC)
+	if repo.lastCreateUserBudget.UserID != userID {
+		t.Fatalf("created user id = %d, want %d", repo.lastCreateUserBudget.UserID, userID)
+	}
+	if repo.lastCreateUserBudget.PeriodStart.Time != wantStart || repo.lastCreateUserBudget.PeriodEnd.Time != wantEnd {
+		t.Fatalf("created period = %s-%s, want %s-%s", repo.lastCreateUserBudget.PeriodStart.Time, repo.lastCreateUserBudget.PeriodEnd.Time, wantStart, wantEnd)
+	}
+	if repo.lastCreateUserBudget.SourceBudgetID != nil {
+		t.Fatalf("source budget id = %v, want nil", repo.lastCreateUserBudget.SourceBudgetID)
 	}
 }
 

--- a/internal/app/budgets_test.go
+++ b/internal/app/budgets_test.go
@@ -303,6 +303,159 @@ func TestGetMonthlyBudgetCreatesEmptyUserBudgetWhenMissing(t *testing.T) {
 	}
 }
 
+func TestGetMonthlyBudgetCreatesEmptyHouseholdBudgetWhenNoPriorBudget(t *testing.T) {
+	householdID := int64(7)
+	repo := &fakeRepo{}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	budget, err := svc.GetMonthlyBudget(context.Background(), GetMonthlyBudgetRequest{
+		HouseholdID:     &householdID,
+		Year:            2026,
+		Month:           7,
+		CreateIfMissing: true,
+	})
+
+	if err != nil {
+		t.Fatalf("GetMonthlyBudget returned error: %v", err)
+	}
+	if budget.ID == 0 || budget.HouseholdID == nil || *budget.HouseholdID != householdID {
+		t.Fatalf("budget = %+v, want created household budget", budget)
+	}
+	if repo.lastLatestPriorHouseholdBudget.HouseholdID != householdID {
+		t.Fatalf("latest prior household id = %d, want %d", repo.lastLatestPriorHouseholdBudget.HouseholdID, householdID)
+	}
+	wantStart := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	if repo.lastLatestPriorHouseholdBudget.PeriodStart.Time != wantStart {
+		t.Fatalf("latest prior period start = %s, want %s", repo.lastLatestPriorHouseholdBudget.PeriodStart.Time, wantStart)
+	}
+	if repo.lastCreateHouseholdBudget.SourceBudgetID != nil {
+		t.Fatalf("source budget id = %v, want nil", repo.lastCreateHouseholdBudget.SourceBudgetID)
+	}
+	if len(repo.createdBudgetLines) != 0 {
+		t.Fatalf("created budget lines = %+v, want none", repo.createdBudgetLines)
+	}
+}
+
+func TestGetMonthlyBudgetCopiesLatestPriorHouseholdBudgetWhenMissing(t *testing.T) {
+	householdID := int64(7)
+	sourceID := int64(7)
+	targetID := int64(12)
+	julyStart := pgtype.Date{Time: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), Valid: true}
+	julyEnd := pgtype.Date{Time: time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC), Valid: true}
+	groceriesAllocation, err := parseBudgetNumeric("250.25")
+	if err != nil {
+		t.Fatalf("parseBudgetNumeric returned error: %v", err)
+	}
+	rentAllocation, err := parseBudgetNumeric("1200.00")
+	if err != nil {
+		t.Fatalf("parseBudgetNumeric returned error: %v", err)
+	}
+	repo := &fakeRepo{
+		latestPriorHousehold: sqlc.Budget{
+			ID:          sourceID,
+			HouseholdID: &householdID,
+		},
+		createdHouseholdBudget: sqlc.Budget{
+			ID:             targetID,
+			HouseholdID:    &householdID,
+			PeriodStart:    julyStart,
+			PeriodEnd:      julyEnd,
+			SourceBudgetID: &sourceID,
+		},
+		budgetLines: []sqlc.BudgetLine{
+			{ID: 101, BudgetID: sourceID, Name: "Groceries", AllocationAmount: groceriesAllocation, SortOrder: 1},
+			{ID: 102, BudgetID: sourceID, Name: "Rent", AllocationAmount: rentAllocation, SortOrder: 2},
+		},
+		budgetLineCategories: []sqlc.ListBudgetLineCategoriesRow{
+			{BudgetID: sourceID, BudgetLineID: 101, CategoryID: 3, CategoryCode: "groceries", CategoryName: "Groceries"},
+		},
+		createdBudgetLineRows: []sqlc.BudgetLine{
+			{ID: 201, BudgetID: targetID, Name: "Groceries", AllocationAmount: groceriesAllocation, SortOrder: 1},
+			{ID: 202, BudgetID: targetID, Name: "Rent", AllocationAmount: rentAllocation, SortOrder: 2},
+		},
+	}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	budget, err := svc.GetMonthlyBudget(context.Background(), GetMonthlyBudgetRequest{
+		HouseholdID:     &householdID,
+		Year:            2026,
+		Month:           7,
+		CreateIfMissing: true,
+	})
+
+	if err != nil {
+		t.Fatalf("GetMonthlyBudget returned error: %v", err)
+	}
+	if budget.SourceBudgetID == nil || *budget.SourceBudgetID != sourceID {
+		t.Fatalf("source budget id = %v, want %d", budget.SourceBudgetID, sourceID)
+	}
+	if repo.lastCreateHouseholdBudget.SourceBudgetID == nil || *repo.lastCreateHouseholdBudget.SourceBudgetID != sourceID {
+		t.Fatalf("created source budget id = %v, want %d", repo.lastCreateHouseholdBudget.SourceBudgetID, sourceID)
+	}
+	if len(repo.createdBudgetLines) != 2 {
+		t.Fatalf("created budget lines = %+v, want 2 lines", repo.createdBudgetLines)
+	}
+	wantLines := []sqlc.CreateBudgetLineParams{
+		{BudgetID: targetID, Name: "Groceries", AllocationAmount: groceriesAllocation, SortOrder: 1},
+		{BudgetID: targetID, Name: "Rent", AllocationAmount: rentAllocation, SortOrder: 2},
+	}
+	for i, want := range wantLines {
+		got := repo.createdBudgetLines[i]
+		if got.BudgetID != want.BudgetID || got.Name != want.Name || got.SortOrder != want.SortOrder || budgetNumericString(got.AllocationAmount) != budgetNumericString(want.AllocationAmount) {
+			t.Fatalf("created budget line %d = %+v, want %+v", i, got, want)
+		}
+	}
+	if len(repo.createdBudgetLineCategories) != 1 {
+		t.Fatalf("created budget line categories = %+v, want one mapping", repo.createdBudgetLineCategories)
+	}
+	wantCategory := sqlc.CreateBudgetLineCategoryParams{BudgetID: targetID, BudgetLineID: 201, CategoryID: 3}
+	if repo.createdBudgetLineCategories[0] != wantCategory {
+		t.Fatalf("created budget line category = %+v, want %+v", repo.createdBudgetLineCategories[0], wantCategory)
+	}
+}
+
+func TestGetMonthlyBudgetCopiesLatestPriorUserBudgetWhenMissing(t *testing.T) {
+	userID := int64(8)
+	sourceID := int64(17)
+	targetID := int64(18)
+	julyStart := pgtype.Date{Time: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), Valid: true}
+	julyEnd := pgtype.Date{Time: time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC), Valid: true}
+	repo := &fakeRepo{
+		latestPriorUser: sqlc.Budget{
+			ID:     sourceID,
+			UserID: &userID,
+		},
+		createdUserBudget: sqlc.Budget{
+			ID:             targetID,
+			UserID:         &userID,
+			PeriodStart:    julyStart,
+			PeriodEnd:      julyEnd,
+			SourceBudgetID: &sourceID,
+		},
+	}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	budget, err := svc.GetMonthlyBudget(context.Background(), GetMonthlyBudgetRequest{
+		UserID:          &userID,
+		Year:            2026,
+		Month:           7,
+		CreateIfMissing: true,
+	})
+
+	if err != nil {
+		t.Fatalf("GetMonthlyBudget returned error: %v", err)
+	}
+	if repo.lastLatestPriorUserBudget.UserID != userID {
+		t.Fatalf("latest prior user id = %d, want %d", repo.lastLatestPriorUserBudget.UserID, userID)
+	}
+	if budget.SourceBudgetID == nil || *budget.SourceBudgetID != sourceID {
+		t.Fatalf("source budget id = %v, want %d", budget.SourceBudgetID, sourceID)
+	}
+	if repo.lastCreateUserBudget.SourceBudgetID == nil || *repo.lastCreateUserBudget.SourceBudgetID != sourceID {
+		t.Fatalf("created source budget id = %v, want %d", repo.lastCreateUserBudget.SourceBudgetID, sourceID)
+	}
+}
+
 func int64Ptr(value int64) *int64 {
 	return &value
 }

--- a/internal/app/budgets_test.go
+++ b/internal/app/budgets_test.go
@@ -543,6 +543,157 @@ func TestGetMonthlyBudgetReturnsDatabaseErrorWhenCopyNeedsMissingTransactor(t *t
 	}
 }
 
+func TestCreateBudgetLineResolvesCategoryCodes(t *testing.T) {
+	allocation, err := parseBudgetNumeric("800.00")
+	if err != nil {
+		t.Fatalf("parseBudgetNumeric returned error: %v", err)
+	}
+	repo := &fakeRepo{
+		budgetByID:     sqlc.Budget{ID: 12},
+		categoryByCode: sqlc.Category{ID: 3, Code: "groceries", Name: "Groceries", IsActive: true},
+		maxSortOrder:   2,
+		createdBudgetLineRows: []sqlc.BudgetLine{
+			{ID: 44, BudgetID: 12, Name: "Groceries", AllocationAmount: allocation, SortOrder: 3},
+		},
+	}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	line, err := svc.CreateBudgetLine(context.Background(), CreateBudgetLineRequest{
+		BudgetID:         12,
+		Name:             " Groceries ",
+		AllocationAmount: "800.00",
+		CategoryCodes:    []string{"groceries"},
+	})
+
+	if err != nil {
+		t.Fatalf("CreateBudgetLine returned error: %v", err)
+	}
+	if line.ID != 44 || line.BudgetID != 12 || line.Name != "Groceries" || line.SortOrder != 3 || line.AllocationAmount != "800.00" {
+		t.Fatalf("line = %+v, want created groceries line", line)
+	}
+	if len(line.Categories) != 1 || line.Categories[0].ID != 3 || line.Categories[0].Code != "groceries" {
+		t.Fatalf("line categories = %+v, want groceries", line.Categories)
+	}
+	if len(repo.createdBudgetLines) != 1 || repo.createdBudgetLines[0].SortOrder != 3 || budgetNumericString(repo.createdBudgetLines[0].AllocationAmount) != "800.00" {
+		t.Fatalf("created budget lines = %+v, want next sort order and normalized amount", repo.createdBudgetLines)
+	}
+	if len(repo.createdBudgetLineCategories) != 1 || repo.createdBudgetLineCategories[0].CategoryID != 3 {
+		t.Fatalf("created mappings = %+v, want category 3", repo.createdBudgetLineCategories)
+	}
+}
+
+func TestCreateBudgetLineRejectsReusedCategory(t *testing.T) {
+	repo := &fakeRepo{
+		budgetByID:     sqlc.Budget{ID: 12},
+		categoryByCode: sqlc.Category{ID: 3, Code: "groceries", Name: "Groceries", IsActive: true},
+		budgetLineCategories: []sqlc.ListBudgetLineCategoriesRow{
+			{BudgetID: 12, BudgetLineID: 40, CategoryID: 3, CategoryCode: "groceries", CategoryName: "Groceries"},
+		},
+	}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	_, err := svc.CreateBudgetLine(context.Background(), CreateBudgetLineRequest{
+		BudgetID:         12,
+		Name:             "Food",
+		AllocationAmount: "800.00",
+		CategoryCodes:    []string{"groceries"},
+	})
+
+	if appErr, ok := err.(*AppError); !ok || appErr.Code != CodeValidationError {
+		t.Fatalf("err = %v, want validation error", err)
+	}
+	if len(repo.createdBudgetLines) != 0 {
+		t.Fatalf("created budget lines = %+v, want none", repo.createdBudgetLines)
+	}
+}
+
+func TestUpdateBudgetLineReplacesOnlyThatLineCategories(t *testing.T) {
+	oldAllocation, err := parseBudgetNumeric("800.00")
+	if err != nil {
+		t.Fatalf("parseBudgetNumeric returned error: %v", err)
+	}
+	newAllocation, err := parseBudgetNumeric("900.00")
+	if err != nil {
+		t.Fatalf("parseBudgetNumeric returned error: %v", err)
+	}
+	repo := &fakeRepo{
+		budgetLineByID:    sqlc.BudgetLine{ID: 44, BudgetID: 12, Name: "Groceries", AllocationAmount: oldAllocation, SortOrder: 1},
+		categoryByCode:    sqlc.Category{ID: 3, Code: "groceries", Name: "Groceries", IsActive: true},
+		updatedBudgetLine: sqlc.BudgetLine{ID: 44, BudgetID: 12, Name: "Groceries", AllocationAmount: newAllocation, SortOrder: 1},
+	}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	line, err := svc.UpdateBudgetLine(context.Background(), UpdateBudgetLineRequest{
+		LineID:           44,
+		AllocationAmount: strPtr("900.00"),
+		CategoryCodes:    &[]string{"groceries"},
+	})
+
+	if err != nil {
+		t.Fatalf("UpdateBudgetLine returned error: %v", err)
+	}
+	if line.ID != 44 || line.AllocationAmount != "900.00" {
+		t.Fatalf("line = %+v, want updated line amount", line)
+	}
+	if !repo.lastUpdateBudgetLine.SetAllocationAmount || budgetNumericString(repo.lastUpdateBudgetLine.AllocationAmount) != "900.00" {
+		t.Fatalf("lastUpdateBudgetLine = %+v, want amount update", repo.lastUpdateBudgetLine)
+	}
+	if repo.deletedBudgetLineCategoryID != 44 {
+		t.Fatalf("deletedBudgetLineCategoryID = %d, want 44", repo.deletedBudgetLineCategoryID)
+	}
+	if len(repo.createdBudgetLineCategories) != 1 || repo.createdBudgetLineCategories[0].BudgetLineID != 44 {
+		t.Fatalf("created mappings = %+v, want mapping for line 44", repo.createdBudgetLineCategories)
+	}
+}
+
+func TestUpdateBudgetLineCanClearCategories(t *testing.T) {
+	allocation, err := parseBudgetNumeric("100.00")
+	if err != nil {
+		t.Fatalf("parseBudgetNumeric returned error: %v", err)
+	}
+	repo := &fakeRepo{
+		budgetLineByID:    sqlc.BudgetLine{ID: 44, BudgetID: 12, Name: "Savings", AllocationAmount: allocation, SortOrder: 1},
+		updatedBudgetLine: sqlc.BudgetLine{ID: 44, BudgetID: 12, Name: "Savings", AllocationAmount: allocation, SortOrder: 1},
+		budgetLineCategories: []sqlc.ListBudgetLineCategoriesRow{
+			{BudgetID: 12, BudgetLineID: 44, CategoryID: 3, CategoryCode: "groceries", CategoryName: "Groceries"},
+		},
+	}
+	svc := NewService(repo, &fakeTransactionService{})
+	emptyCodes := []string{}
+
+	line, err := svc.UpdateBudgetLine(context.Background(), UpdateBudgetLineRequest{
+		LineID:        44,
+		CategoryCodes: &emptyCodes,
+	})
+
+	if err != nil {
+		t.Fatalf("UpdateBudgetLine returned error: %v", err)
+	}
+	if repo.deletedBudgetLineCategoryID != 44 {
+		t.Fatalf("deletedBudgetLineCategoryID = %d, want 44", repo.deletedBudgetLineCategoryID)
+	}
+	if len(repo.createdBudgetLineCategories) != 0 {
+		t.Fatalf("created mappings = %+v, want none", repo.createdBudgetLineCategories)
+	}
+	if len(line.Categories) != 0 {
+		t.Fatalf("line categories = %+v, want none", line.Categories)
+	}
+}
+
+func TestDeleteBudgetLineDeletesLine(t *testing.T) {
+	repo := &fakeRepo{}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	err := svc.DeleteBudgetLine(context.Background(), 44)
+
+	if err != nil {
+		t.Fatalf("DeleteBudgetLine returned error: %v", err)
+	}
+	if repo.deletedBudgetLineID != 44 {
+		t.Fatalf("deletedBudgetLineID = %d, want 44", repo.deletedBudgetLineID)
+	}
+}
+
 func int64Ptr(value int64) *int64 {
 	return &value
 }

--- a/internal/app/budgets_test.go
+++ b/internal/app/budgets_test.go
@@ -1,0 +1,157 @@
+package app
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"rdmm404/voltr-finance/internal/database/sqlc"
+)
+
+func TestMonthlyBudgetPeriodReturnsUTCMonthBounds(t *testing.T) {
+	start, end, err := monthlyBudgetPeriod(2026, 5)
+
+	if err != nil {
+		t.Fatalf("monthlyBudgetPeriod returned error: %v", err)
+	}
+	wantStart := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	wantEnd := time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC)
+	if !start.Equal(wantStart) {
+		t.Fatalf("start = %s, want %s", start, wantStart)
+	}
+	if !end.Equal(wantEnd) {
+		t.Fatalf("end = %s, want %s", end, wantEnd)
+	}
+	if start.Location() != time.UTC || end.Location() != time.UTC {
+		t.Fatalf("locations = %s/%s, want UTC", start.Location(), end.Location())
+	}
+}
+
+func TestMonthlyBudgetPeriodRejectsInvalidMonth(t *testing.T) {
+	_, _, err := monthlyBudgetPeriod(2026, 13)
+
+	if appErr, ok := err.(*AppError); !ok || appErr.Code != CodeValidationError {
+		t.Fatalf("err = %v, want validation error", err)
+	}
+}
+
+func TestGetMonthlyBudgetRejectsMissingOwner(t *testing.T) {
+	svc := NewService(&fakeRepo{}, &fakeTransactionService{})
+
+	_, err := svc.GetMonthlyBudget(context.Background(), GetMonthlyBudgetRequest{
+		Year:  2026,
+		Month: 5,
+	})
+
+	if appErr, ok := err.(*AppError); !ok || appErr.Code != CodeValidationError {
+		t.Fatalf("err = %v, want validation error", err)
+	}
+}
+
+func TestGetMonthlyBudgetRejectsHouseholdAndUserOwners(t *testing.T) {
+	svc := NewService(&fakeRepo{}, &fakeTransactionService{})
+
+	_, err := svc.GetMonthlyBudget(context.Background(), GetMonthlyBudgetRequest{
+		HouseholdID: int64Ptr(1),
+		UserID:      int64Ptr(2),
+		Year:        2026,
+		Month:       5,
+	})
+
+	if appErr, ok := err.(*AppError); !ok || appErr.Code != CodeValidationError {
+		t.Fatalf("err = %v, want validation error", err)
+	}
+}
+
+func TestGetMonthlyBudgetReturnsExistingHouseholdBudget(t *testing.T) {
+	householdID := int64(7)
+	start := pgtype.Date{Time: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC), Valid: true}
+	end := pgtype.Date{Time: time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC), Valid: true}
+	repo := &fakeRepo{
+		householdBudgetByPeriod: sqlc.Budget{
+			ID:          11,
+			HouseholdID: &householdID,
+			PeriodStart: start,
+			PeriodEnd:   end,
+		},
+		budgetLines: []sqlc.BudgetLine{
+			{
+				ID:               21,
+				BudgetID:         11,
+				Name:             "Groceries",
+				AllocationAmount: pgtype.Numeric{Int: big.NewInt(12550), Exp: -2, Valid: true},
+				SortOrder:        1,
+			},
+		},
+		budgetLineCategories: []sqlc.ListBudgetLineCategoriesRow{
+			{BudgetID: 11, BudgetLineID: 21, CategoryID: 31, CategoryCode: "groceries", CategoryName: "Groceries"},
+		},
+	}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	budget, err := svc.GetMonthlyBudget(context.Background(), GetMonthlyBudgetRequest{
+		HouseholdID: &householdID,
+		Year:        2026,
+		Month:       5,
+	})
+
+	if err != nil {
+		t.Fatalf("GetMonthlyBudget returned error: %v", err)
+	}
+	if budget.ID != 11 || budget.HouseholdID == nil || *budget.HouseholdID != householdID || budget.UserID != nil {
+		t.Fatalf("budget owner = %+v, want household budget", budget)
+	}
+	if !budget.PeriodStart.Equal(start.Time) || !budget.PeriodEnd.Equal(end.Time) {
+		t.Fatalf("period = %s-%s, want %s-%s", budget.PeriodStart, budget.PeriodEnd, start.Time, end.Time)
+	}
+	if repo.lastHouseholdBudgetPeriodStart != start.Time {
+		t.Fatalf("period start passed to repo = %s, want %s", repo.lastHouseholdBudgetPeriodStart, start.Time)
+	}
+	if len(budget.Lines) != 1 || budget.Lines[0].AllocationAmount != "125.50" {
+		t.Fatalf("lines = %+v, want mapped line with allocation amount string", budget.Lines)
+	}
+	if len(budget.Lines[0].Categories) != 1 || budget.Lines[0].Categories[0].Code != "groceries" {
+		t.Fatalf("categories = %+v, want groceries category", budget.Lines[0].Categories)
+	}
+}
+
+func TestGetMonthlyBudgetCreatesEmptyHouseholdBudgetWhenMissing(t *testing.T) {
+	householdID := int64(7)
+	repo := &fakeRepo{}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	budget, err := svc.GetMonthlyBudget(context.Background(), GetMonthlyBudgetRequest{
+		HouseholdID:     &householdID,
+		Year:            2026,
+		Month:           5,
+		CreateIfMissing: true,
+	})
+
+	if err != nil {
+		t.Fatalf("GetMonthlyBudget returned error: %v", err)
+	}
+	if budget.ID == 0 || budget.HouseholdID == nil || *budget.HouseholdID != householdID {
+		t.Fatalf("budget = %+v, want created household budget", budget)
+	}
+	wantStart := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	wantEnd := time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC)
+	if repo.lastCreateHouseholdBudget.HouseholdID != householdID {
+		t.Fatalf("created household id = %d, want %d", repo.lastCreateHouseholdBudget.HouseholdID, householdID)
+	}
+	if repo.lastCreateHouseholdBudget.PeriodStart.Time != wantStart || repo.lastCreateHouseholdBudget.PeriodEnd.Time != wantEnd {
+		t.Fatalf("created period = %s-%s, want %s-%s", repo.lastCreateHouseholdBudget.PeriodStart.Time, repo.lastCreateHouseholdBudget.PeriodEnd.Time, wantStart, wantEnd)
+	}
+	if repo.lastCreateHouseholdBudget.SourceBudgetID != nil {
+		t.Fatalf("source budget id = %v, want nil", repo.lastCreateHouseholdBudget.SourceBudgetID)
+	}
+	if len(budget.Lines) != 0 {
+		t.Fatalf("lines = %+v, want empty budget", budget.Lines)
+	}
+}
+
+func int64Ptr(value int64) *int64 {
+	return &value
+}

--- a/internal/app/budgets_test.go
+++ b/internal/app/budgets_test.go
@@ -694,6 +694,100 @@ func TestDeleteBudgetLineDeletesLine(t *testing.T) {
 	}
 }
 
+func TestGetBudgetReportDerivesActualsFromCategories(t *testing.T) {
+	householdID := int64(1)
+	groceriesAllocation, err := parseBudgetNumeric("800.00")
+	if err != nil {
+		t.Fatalf("parseBudgetNumeric returned error: %v", err)
+	}
+	savingsAllocation, err := parseBudgetNumeric("500.00")
+	if err != nil {
+		t.Fatalf("parseBudgetNumeric returned error: %v", err)
+	}
+	repo := &fakeRepo{
+		budgetByID: sqlc.Budget{
+			ID:          12,
+			HouseholdID: &householdID,
+			PeriodStart: pgtype.Date{Time: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC), Valid: true},
+			PeriodEnd:   pgtype.Date{Time: time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC), Valid: true},
+		},
+		budgetLines: []sqlc.BudgetLine{
+			{ID: 44, BudgetID: 12, Name: "Groceries", AllocationAmount: groceriesAllocation, SortOrder: 1},
+			{ID: 45, BudgetID: 12, Name: "Savings", AllocationAmount: savingsAllocation, SortOrder: 2},
+		},
+		budgetLineCategories: []sqlc.ListBudgetLineCategoriesRow{
+			{BudgetID: 12, BudgetLineID: 44, CategoryID: 3, CategoryCode: "groceries", CategoryName: "Groceries"},
+		},
+		budgetTransactions: []sqlc.ListBudgetTransactionsRow{
+			{CategoryID: 3, ActualAmount: 570.25},
+		},
+		uncategorizedBudgetTransactions: 123.45,
+	}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	report, err := svc.GetBudgetReport(context.Background(), 12)
+
+	if err != nil {
+		t.Fatalf("GetBudgetReport returned error: %v", err)
+	}
+	if len(report.Lines) != 2 {
+		t.Fatalf("lines = %d, want 2", len(report.Lines))
+	}
+	if report.Lines[0].ActualAmount != "570.25" || report.Lines[0].RemainingAmount != "229.75" {
+		t.Fatalf("groceries line = %+v, want actual 570.25 remaining 229.75", report.Lines[0])
+	}
+	if report.Lines[1].ActualAmount != "0.00" || report.Lines[1].RemainingAmount != "500.00" {
+		t.Fatalf("savings line = %+v, want zero actual and full remaining", report.Lines[1])
+	}
+	if report.Totals.AllocationAmount != "1300.00" || report.Totals.ActualAmount != "570.25" || report.Totals.RemainingAmount != "729.75" {
+		t.Fatalf("totals = %+v, want allocation 1300 actual 570.25 remaining 729.75", report.Totals)
+	}
+	if report.Totals.UncategorizedActualAmount != "123.45" {
+		t.Fatalf("uncategorized = %q, want 123.45", report.Totals.UncategorizedActualAmount)
+	}
+	if repo.lastListBudgetTransactions.HouseholdID == nil || *repo.lastListBudgetTransactions.HouseholdID != householdID || repo.lastListBudgetTransactions.UserID != nil {
+		t.Fatalf("transaction params = %+v, want household scope", repo.lastListBudgetTransactions)
+	}
+	if repo.lastSumUncategorizedBudgetTransactions.PeriodStart.Time != report.Budget.PeriodStart {
+		t.Fatalf("uncategorized params period start = %s, want %s", repo.lastSumUncategorizedBudgetTransactions.PeriodStart.Time, report.Budget.PeriodStart)
+	}
+}
+
+func TestGetBudgetReportNegativeTransactionsReduceActuals(t *testing.T) {
+	householdID := int64(1)
+	allocation, err := parseBudgetNumeric("100.00")
+	if err != nil {
+		t.Fatalf("parseBudgetNumeric returned error: %v", err)
+	}
+	repo := &fakeRepo{
+		budgetByID: sqlc.Budget{
+			ID:          12,
+			HouseholdID: &householdID,
+			PeriodStart: pgtype.Date{Time: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC), Valid: true},
+			PeriodEnd:   pgtype.Date{Time: time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC), Valid: true},
+		},
+		budgetLines: []sqlc.BudgetLine{
+			{ID: 44, BudgetID: 12, Name: "Groceries", AllocationAmount: allocation, SortOrder: 1},
+		},
+		budgetLineCategories: []sqlc.ListBudgetLineCategoriesRow{
+			{BudgetID: 12, BudgetLineID: 44, CategoryID: 3, CategoryCode: "groceries", CategoryName: "Groceries"},
+		},
+		budgetTransactions: []sqlc.ListBudgetTransactionsRow{
+			{CategoryID: 3, ActualAmount: 60.00},
+		},
+	}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	report, err := svc.GetBudgetReport(context.Background(), 12)
+
+	if err != nil {
+		t.Fatalf("GetBudgetReport returned error: %v", err)
+	}
+	if report.Lines[0].ActualAmount != "60.00" || report.Lines[0].RemainingAmount != "40.00" {
+		t.Fatalf("line = %+v, want net actual 60.00 remaining 40.00", report.Lines[0])
+	}
+}
+
 func int64Ptr(value int64) *int64 {
 	return &value
 }

--- a/internal/app/budgets_test.go
+++ b/internal/app/budgets_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"rdmm404/voltr-finance/internal/database/sqlc"
@@ -336,6 +337,40 @@ func TestGetMonthlyBudgetCreatesEmptyHouseholdBudgetWhenNoPriorBudget(t *testing
 	}
 }
 
+func TestGetMonthlyBudgetReturnsExistingBudgetAfterConcurrentCreate(t *testing.T) {
+	householdID := int64(7)
+	julyStart := pgtype.Date{Time: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), Valid: true}
+	julyEnd := pgtype.Date{Time: time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC), Valid: true}
+	repo := &fakeRepo{
+		householdBudgetByPeriodMisses: 1,
+		householdBudgetByPeriod: sqlc.Budget{
+			ID:          55,
+			HouseholdID: &householdID,
+			PeriodStart: julyStart,
+			PeriodEnd:   julyEnd,
+		},
+		createHouseholdBudgetErr: &pgconn.PgError{Code: "23505"},
+	}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	budget, err := svc.GetMonthlyBudget(context.Background(), GetMonthlyBudgetRequest{
+		HouseholdID:     &householdID,
+		Year:            2026,
+		Month:           7,
+		CreateIfMissing: true,
+	})
+
+	if err != nil {
+		t.Fatalf("GetMonthlyBudget returned error: %v", err)
+	}
+	if budget.ID != 55 || budget.HouseholdID == nil || *budget.HouseholdID != householdID {
+		t.Fatalf("budget = %+v, want existing concurrently-created budget", budget)
+	}
+	if repo.lastCreateHouseholdBudget.HouseholdID != householdID {
+		t.Fatalf("create household id = %d, want %d", repo.lastCreateHouseholdBudget.HouseholdID, householdID)
+	}
+}
+
 func TestGetMonthlyBudgetCopiesLatestPriorHouseholdBudgetWhenMissing(t *testing.T) {
 	householdID := int64(7)
 	sourceID := int64(7)
@@ -556,7 +591,8 @@ func TestCreateBudgetLineResolvesCategoryCodes(t *testing.T) {
 			{ID: 44, BudgetID: 12, Name: "Groceries", AllocationAmount: allocation, SortOrder: 3},
 		},
 	}
-	svc := NewService(repo, &fakeTransactionService{})
+	transactor := &fakeTransactor{repo: repo}
+	svc := NewServiceWithTransactor(repo, &fakeTransactionService{}, transactor)
 
 	line, err := svc.CreateBudgetLine(context.Background(), CreateBudgetLineRequest{
 		BudgetID:         12,
@@ -580,6 +616,9 @@ func TestCreateBudgetLineResolvesCategoryCodes(t *testing.T) {
 	if len(repo.createdBudgetLineCategories) != 1 || repo.createdBudgetLineCategories[0].CategoryID != 3 {
 		t.Fatalf("created mappings = %+v, want category 3", repo.createdBudgetLineCategories)
 	}
+	if transactor.calls != 1 {
+		t.Fatalf("transaction calls = %d, want 1", transactor.calls)
+	}
 }
 
 func TestCreateBudgetLineRejectsReusedCategory(t *testing.T) {
@@ -590,7 +629,8 @@ func TestCreateBudgetLineRejectsReusedCategory(t *testing.T) {
 			{BudgetID: 12, BudgetLineID: 40, CategoryID: 3, CategoryCode: "groceries", CategoryName: "Groceries"},
 		},
 	}
-	svc := NewService(repo, &fakeTransactionService{})
+	transactor := &fakeTransactor{repo: repo}
+	svc := NewServiceWithTransactor(repo, &fakeTransactionService{}, transactor)
 
 	_, err := svc.CreateBudgetLine(context.Background(), CreateBudgetLineRequest{
 		BudgetID:         12,
@@ -621,7 +661,8 @@ func TestUpdateBudgetLineReplacesOnlyThatLineCategories(t *testing.T) {
 		categoryByCode:    sqlc.Category{ID: 3, Code: "groceries", Name: "Groceries", IsActive: true},
 		updatedBudgetLine: sqlc.BudgetLine{ID: 44, BudgetID: 12, Name: "Groceries", AllocationAmount: newAllocation, SortOrder: 1},
 	}
-	svc := NewService(repo, &fakeTransactionService{})
+	transactor := &fakeTransactor{repo: repo}
+	svc := NewServiceWithTransactor(repo, &fakeTransactionService{}, transactor)
 
 	line, err := svc.UpdateBudgetLine(context.Background(), UpdateBudgetLineRequest{
 		LineID:           44,
@@ -644,6 +685,9 @@ func TestUpdateBudgetLineReplacesOnlyThatLineCategories(t *testing.T) {
 	if len(repo.createdBudgetLineCategories) != 1 || repo.createdBudgetLineCategories[0].BudgetLineID != 44 {
 		t.Fatalf("created mappings = %+v, want mapping for line 44", repo.createdBudgetLineCategories)
 	}
+	if transactor.calls != 1 {
+		t.Fatalf("transaction calls = %d, want 1", transactor.calls)
+	}
 }
 
 func TestUpdateBudgetLineCanClearCategories(t *testing.T) {
@@ -658,7 +702,8 @@ func TestUpdateBudgetLineCanClearCategories(t *testing.T) {
 			{BudgetID: 12, BudgetLineID: 44, CategoryID: 3, CategoryCode: "groceries", CategoryName: "Groceries"},
 		},
 	}
-	svc := NewService(repo, &fakeTransactionService{})
+	transactor := &fakeTransactor{repo: repo}
+	svc := NewServiceWithTransactor(repo, &fakeTransactionService{}, transactor)
 	emptyCodes := []string{}
 
 	line, err := svc.UpdateBudgetLine(context.Background(), UpdateBudgetLineRequest{
@@ -704,6 +749,18 @@ func TestGetBudgetReportDerivesActualsFromCategories(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseBudgetNumeric returned error: %v", err)
 	}
+	groceriesActual, err := parseBudgetNumeric("570.25")
+	if err != nil {
+		t.Fatalf("parseBudgetNumeric returned error: %v", err)
+	}
+	zeroActual, err := parseBudgetNumeric("0.00")
+	if err != nil {
+		t.Fatalf("parseBudgetNumeric returned error: %v", err)
+	}
+	uncategorizedActual, err := parseBudgetNumeric("123.45")
+	if err != nil {
+		t.Fatalf("parseBudgetNumeric returned error: %v", err)
+	}
 	repo := &fakeRepo{
 		budgetByID: sqlc.Budget{
 			ID:          12,
@@ -715,13 +772,14 @@ func TestGetBudgetReportDerivesActualsFromCategories(t *testing.T) {
 			{ID: 44, BudgetID: 12, Name: "Groceries", AllocationAmount: groceriesAllocation, SortOrder: 1},
 			{ID: 45, BudgetID: 12, Name: "Savings", AllocationAmount: savingsAllocation, SortOrder: 2},
 		},
+		budgetReportLines: []sqlc.ListBudgetReportLinesRow{
+			{ID: 44, BudgetID: 12, Name: "Groceries", AllocationAmount: groceriesAllocation, ActualAmount: groceriesActual, SortOrder: 1},
+			{ID: 45, BudgetID: 12, Name: "Savings", AllocationAmount: savingsAllocation, ActualAmount: zeroActual, SortOrder: 2},
+		},
 		budgetLineCategories: []sqlc.ListBudgetLineCategoriesRow{
 			{BudgetID: 12, BudgetLineID: 44, CategoryID: 3, CategoryCode: "groceries", CategoryName: "Groceries"},
 		},
-		budgetTransactions: []sqlc.ListBudgetTransactionsRow{
-			{CategoryID: 3, ActualAmount: 570.25},
-		},
-		uncategorizedBudgetTransactions: 123.45,
+		uncategorizedBudgetTransactions: uncategorizedActual,
 	}
 	svc := NewService(repo, &fakeTransactionService{})
 
@@ -745,17 +803,21 @@ func TestGetBudgetReportDerivesActualsFromCategories(t *testing.T) {
 	if report.Totals.UncategorizedActualAmount != "123.45" {
 		t.Fatalf("uncategorized = %q, want 123.45", report.Totals.UncategorizedActualAmount)
 	}
-	if repo.lastListBudgetTransactions.HouseholdID == nil || *repo.lastListBudgetTransactions.HouseholdID != householdID || repo.lastListBudgetTransactions.UserID != nil {
-		t.Fatalf("transaction params = %+v, want household scope", repo.lastListBudgetTransactions)
+	if repo.lastListBudgetReportLinesBudgetID != 12 {
+		t.Fatalf("report lines budget id = %d, want 12", repo.lastListBudgetReportLinesBudgetID)
 	}
-	if repo.lastSumUncategorizedBudgetTransactions.PeriodStart.Time != report.Budget.PeriodStart {
-		t.Fatalf("uncategorized params period start = %s, want %s", repo.lastSumUncategorizedBudgetTransactions.PeriodStart.Time, report.Budget.PeriodStart)
+	if repo.lastSumUncategorizedBudgetTransactions != 12 {
+		t.Fatalf("uncategorized budget id = %d, want 12", repo.lastSumUncategorizedBudgetTransactions)
 	}
 }
 
 func TestGetBudgetReportNegativeTransactionsReduceActuals(t *testing.T) {
 	householdID := int64(1)
 	allocation, err := parseBudgetNumeric("100.00")
+	if err != nil {
+		t.Fatalf("parseBudgetNumeric returned error: %v", err)
+	}
+	actual, err := parseBudgetNumeric("60.00")
 	if err != nil {
 		t.Fatalf("parseBudgetNumeric returned error: %v", err)
 	}
@@ -769,11 +831,11 @@ func TestGetBudgetReportNegativeTransactionsReduceActuals(t *testing.T) {
 		budgetLines: []sqlc.BudgetLine{
 			{ID: 44, BudgetID: 12, Name: "Groceries", AllocationAmount: allocation, SortOrder: 1},
 		},
+		budgetReportLines: []sqlc.ListBudgetReportLinesRow{
+			{ID: 44, BudgetID: 12, Name: "Groceries", AllocationAmount: allocation, ActualAmount: actual, SortOrder: 1},
+		},
 		budgetLineCategories: []sqlc.ListBudgetLineCategoriesRow{
 			{BudgetID: 12, BudgetLineID: 44, CategoryID: 3, CategoryCode: "groceries", CategoryName: "Groceries"},
-		},
-		budgetTransactions: []sqlc.ListBudgetTransactionsRow{
-			{CategoryID: 3, ActualAmount: 60.00},
 		},
 	}
 	svc := NewService(repo, &fakeTransactionService{})

--- a/internal/app/budgets_test.go
+++ b/internal/app/budgets_test.go
@@ -374,7 +374,8 @@ func TestGetMonthlyBudgetCopiesLatestPriorHouseholdBudgetWhenMissing(t *testing.
 			{ID: 202, BudgetID: targetID, Name: "Rent", AllocationAmount: rentAllocation, SortOrder: 2},
 		},
 	}
-	svc := NewService(repo, &fakeTransactionService{})
+	transactor := &fakeTransactor{repo: repo}
+	svc := NewServiceWithTransactor(repo, &fakeTransactionService{}, transactor)
 
 	budget, err := svc.GetMonthlyBudget(context.Background(), GetMonthlyBudgetRequest{
 		HouseholdID:     &householdID,
@@ -388,6 +389,9 @@ func TestGetMonthlyBudgetCopiesLatestPriorHouseholdBudgetWhenMissing(t *testing.
 	}
 	if budget.SourceBudgetID == nil || *budget.SourceBudgetID != sourceID {
 		t.Fatalf("source budget id = %v, want %d", budget.SourceBudgetID, sourceID)
+	}
+	if transactor.calls != 1 {
+		t.Fatalf("transaction calls = %d, want 1", transactor.calls)
 	}
 	if repo.lastCreateHouseholdBudget.SourceBudgetID == nil || *repo.lastCreateHouseholdBudget.SourceBudgetID != sourceID {
 		t.Fatalf("created source budget id = %v, want %d", repo.lastCreateHouseholdBudget.SourceBudgetID, sourceID)
@@ -412,6 +416,18 @@ func TestGetMonthlyBudgetCopiesLatestPriorHouseholdBudgetWhenMissing(t *testing.
 	if repo.createdBudgetLineCategories[0] != wantCategory {
 		t.Fatalf("created budget line category = %+v, want %+v", repo.createdBudgetLineCategories[0], wantCategory)
 	}
+	if len(budget.Lines) != 2 {
+		t.Fatalf("returned lines = %+v, want two copied target lines", budget.Lines)
+	}
+	if budget.Lines[0].ID != 201 || budget.Lines[0].BudgetID != targetID || budget.Lines[0].Name != "Groceries" || budget.Lines[0].AllocationAmount != "250.25" {
+		t.Fatalf("returned first line = %+v, want copied groceries target line", budget.Lines[0])
+	}
+	if len(budget.Lines[0].Categories) != 1 || budget.Lines[0].Categories[0].ID != 3 || budget.Lines[0].Categories[0].Code != "groceries" {
+		t.Fatalf("returned first line categories = %+v, want copied groceries category", budget.Lines[0].Categories)
+	}
+	if budget.Lines[1].ID != 202 || budget.Lines[1].BudgetID != targetID || budget.Lines[1].Name != "Rent" || budget.Lines[1].AllocationAmount != "1200.00" {
+		t.Fatalf("returned second line = %+v, want copied rent target line", budget.Lines[1])
+	}
 }
 
 func TestGetMonthlyBudgetCopiesLatestPriorUserBudgetWhenMissing(t *testing.T) {
@@ -420,6 +436,10 @@ func TestGetMonthlyBudgetCopiesLatestPriorUserBudgetWhenMissing(t *testing.T) {
 	targetID := int64(18)
 	julyStart := pgtype.Date{Time: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), Valid: true}
 	julyEnd := pgtype.Date{Time: time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC), Valid: true}
+	utilitiesAllocation, err := parseBudgetNumeric("88.40")
+	if err != nil {
+		t.Fatalf("parseBudgetNumeric returned error: %v", err)
+	}
 	repo := &fakeRepo{
 		latestPriorUser: sqlc.Budget{
 			ID:     sourceID,
@@ -432,8 +452,18 @@ func TestGetMonthlyBudgetCopiesLatestPriorUserBudgetWhenMissing(t *testing.T) {
 			PeriodEnd:      julyEnd,
 			SourceBudgetID: &sourceID,
 		},
+		budgetLines: []sqlc.BudgetLine{
+			{ID: 301, BudgetID: sourceID, Name: "Utilities", AllocationAmount: utilitiesAllocation, SortOrder: 4},
+		},
+		budgetLineCategories: []sqlc.ListBudgetLineCategoriesRow{
+			{BudgetID: sourceID, BudgetLineID: 301, CategoryID: 9, CategoryCode: "utilities", CategoryName: "Utilities"},
+		},
+		createdBudgetLineRows: []sqlc.BudgetLine{
+			{ID: 401, BudgetID: targetID, Name: "Utilities", AllocationAmount: utilitiesAllocation, SortOrder: 4},
+		},
 	}
-	svc := NewService(repo, &fakeTransactionService{})
+	transactor := &fakeTransactor{repo: repo}
+	svc := NewServiceWithTransactor(repo, &fakeTransactionService{}, transactor)
 
 	budget, err := svc.GetMonthlyBudget(context.Background(), GetMonthlyBudgetRequest{
 		UserID:          &userID,
@@ -448,11 +478,68 @@ func TestGetMonthlyBudgetCopiesLatestPriorUserBudgetWhenMissing(t *testing.T) {
 	if repo.lastLatestPriorUserBudget.UserID != userID {
 		t.Fatalf("latest prior user id = %d, want %d", repo.lastLatestPriorUserBudget.UserID, userID)
 	}
+	if transactor.calls != 1 {
+		t.Fatalf("transaction calls = %d, want 1", transactor.calls)
+	}
 	if budget.SourceBudgetID == nil || *budget.SourceBudgetID != sourceID {
 		t.Fatalf("source budget id = %v, want %d", budget.SourceBudgetID, sourceID)
 	}
 	if repo.lastCreateUserBudget.SourceBudgetID == nil || *repo.lastCreateUserBudget.SourceBudgetID != sourceID {
 		t.Fatalf("created source budget id = %v, want %d", repo.lastCreateUserBudget.SourceBudgetID, sourceID)
+	}
+	if len(repo.createdBudgetLines) != 1 {
+		t.Fatalf("created budget lines = %+v, want one line", repo.createdBudgetLines)
+	}
+	wantLine := sqlc.CreateBudgetLineParams{BudgetID: targetID, Name: "Utilities", AllocationAmount: utilitiesAllocation, SortOrder: 4}
+	gotLine := repo.createdBudgetLines[0]
+	if gotLine.BudgetID != wantLine.BudgetID || gotLine.Name != wantLine.Name || gotLine.SortOrder != wantLine.SortOrder || budgetNumericString(gotLine.AllocationAmount) != budgetNumericString(wantLine.AllocationAmount) {
+		t.Fatalf("created budget line = %+v, want %+v", gotLine, wantLine)
+	}
+	if len(repo.createdBudgetLineCategories) != 1 {
+		t.Fatalf("created budget line categories = %+v, want one mapping", repo.createdBudgetLineCategories)
+	}
+	wantCategory := sqlc.CreateBudgetLineCategoryParams{BudgetID: targetID, BudgetLineID: 401, CategoryID: 9}
+	if repo.createdBudgetLineCategories[0] != wantCategory {
+		t.Fatalf("created budget line category = %+v, want %+v", repo.createdBudgetLineCategories[0], wantCategory)
+	}
+	if len(budget.Lines) != 1 || budget.Lines[0].ID != 401 || budget.Lines[0].BudgetID != targetID || budget.Lines[0].Name != "Utilities" {
+		t.Fatalf("returned lines = %+v, want copied user target line", budget.Lines)
+	}
+	if len(budget.Lines[0].Categories) != 1 || budget.Lines[0].Categories[0].ID != 9 || budget.Lines[0].Categories[0].Code != "utilities" {
+		t.Fatalf("returned categories = %+v, want copied utilities category", budget.Lines[0].Categories)
+	}
+}
+
+func TestGetMonthlyBudgetReturnsDatabaseErrorWhenCopyNeedsMissingTransactor(t *testing.T) {
+	householdID := int64(7)
+	sourceID := int64(7)
+	amount, err := parseBudgetNumeric("10.00")
+	if err != nil {
+		t.Fatalf("parseBudgetNumeric returned error: %v", err)
+	}
+	repo := &fakeRepo{
+		latestPriorHousehold: sqlc.Budget{
+			ID:          sourceID,
+			HouseholdID: &householdID,
+		},
+		budgetLines: []sqlc.BudgetLine{
+			{ID: 101, BudgetID: sourceID, Name: "Groceries", AllocationAmount: amount, SortOrder: 1},
+		},
+	}
+	svc := NewService(repo, &fakeTransactionService{})
+
+	_, err = svc.GetMonthlyBudget(context.Background(), GetMonthlyBudgetRequest{
+		HouseholdID:     &householdID,
+		Year:            2026,
+		Month:           7,
+		CreateIfMissing: true,
+	})
+
+	if appErr, ok := err.(*AppError); !ok || appErr.Code != CodeDatabaseError {
+		t.Fatalf("err = %v, want database error", err)
+	}
+	if len(repo.createdBudgetLines) != 0 {
+		t.Fatalf("created budget lines = %+v, want none", repo.createdBudgetLines)
 	}
 }
 

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
 	"rdmm404/voltr-finance/internal/database/sqlc"
 	"rdmm404/voltr-finance/internal/transaction"
 )
@@ -80,13 +83,47 @@ type TransactionService interface {
 	RestoreTransactionsById(context.Context, []int64, int64) transaction.TransactionResult
 }
 
+type Transactor interface {
+	WithinTx(ctx context.Context, fn func(Repository) error) error
+}
+
+type SQLCTransactor struct {
+	pool    *pgxpool.Pool
+	queries *sqlc.Queries
+}
+
+func NewSQLCTransactor(pool *pgxpool.Pool, queries *sqlc.Queries) *SQLCTransactor {
+	return &SQLCTransactor{pool: pool, queries: queries}
+}
+
+func (t *SQLCTransactor) WithinTx(ctx context.Context, fn func(Repository) error) error {
+	tx, err := t.pool.Begin(ctx)
+	if err != nil {
+		return mapBudgetError(err)
+	}
+	defer tx.Rollback(ctx)
+
+	if err := fn(t.queries.WithTx(tx)); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return mapBudgetError(err)
+	}
+	return nil
+}
+
 type Service struct {
 	repo         Repository
 	transactions TransactionService
+	transactor   Transactor
 }
 
 func NewService(repo Repository, transactions TransactionService) *Service {
 	return &Service{repo: repo, transactions: transactions}
+}
+
+func NewServiceWithTransactor(repo Repository, transactions TransactionService, transactor Transactor) *Service {
+	return &Service{repo: repo, transactions: transactions, transactor: transactor}
 }
 
 func mapUserError(err error) error {

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"rdmm404/voltr-finance/internal/database/sqlc"
@@ -71,8 +72,8 @@ type BudgetRepository interface {
 	DeleteBudgetLine(context.Context, int64) error
 	DeleteBudgetLineCategories(context.Context, int64) error
 	CreateBudgetLineCategory(context.Context, sqlc.CreateBudgetLineCategoryParams) error
-	ListBudgetTransactions(context.Context, sqlc.ListBudgetTransactionsParams) ([]sqlc.ListBudgetTransactionsRow, error)
-	SumUncategorizedBudgetTransactions(context.Context, sqlc.SumUncategorizedBudgetTransactionsParams) (float32, error)
+	ListBudgetReportLines(context.Context, int64) ([]sqlc.ListBudgetReportLinesRow, error)
+	SumUncategorizedBudgetTransactions(context.Context, int64) (pgtype.Numeric, error)
 }
 
 type TransactionService interface {

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -13,6 +13,7 @@ type Repository interface {
 	HouseholdRepository
 	TransactionRepository
 	CategoryRepository
+	BudgetRepository
 }
 
 type UserRepository interface {
@@ -48,6 +49,27 @@ type CategoryRepository interface {
 	GetActiveCategoryByCode(context.Context, string) (sqlc.Category, error)
 	UpdateCategory(context.Context, sqlc.UpdateCategoryParams) (sqlc.Category, error)
 	DeactivateCategory(context.Context, string) (sqlc.Category, error)
+}
+
+type BudgetRepository interface {
+	GetHouseholdBudgetByPeriod(context.Context, sqlc.GetHouseholdBudgetByPeriodParams) (sqlc.Budget, error)
+	GetUserBudgetByPeriod(context.Context, sqlc.GetUserBudgetByPeriodParams) (sqlc.Budget, error)
+	GetBudgetById(context.Context, int64) (sqlc.Budget, error)
+	GetLatestPriorHouseholdBudget(context.Context, sqlc.GetLatestPriorHouseholdBudgetParams) (sqlc.Budget, error)
+	GetLatestPriorUserBudget(context.Context, sqlc.GetLatestPriorUserBudgetParams) (sqlc.Budget, error)
+	ListBudgetLines(context.Context, int64) ([]sqlc.BudgetLine, error)
+	ListBudgetLineCategories(context.Context, int64) ([]sqlc.ListBudgetLineCategoriesRow, error)
+	GetBudgetLineById(context.Context, int64) (sqlc.BudgetLine, error)
+	GetMaxBudgetLineSortOrder(context.Context, int64) (int32, error)
+	CreateHouseholdBudget(context.Context, sqlc.CreateHouseholdBudgetParams) (sqlc.Budget, error)
+	CreateUserBudget(context.Context, sqlc.CreateUserBudgetParams) (sqlc.Budget, error)
+	CreateBudgetLine(context.Context, sqlc.CreateBudgetLineParams) (sqlc.BudgetLine, error)
+	UpdateBudgetLine(context.Context, sqlc.UpdateBudgetLineParams) (sqlc.BudgetLine, error)
+	DeleteBudgetLine(context.Context, int64) error
+	DeleteBudgetLineCategories(context.Context, int64) error
+	CreateBudgetLineCategory(context.Context, sqlc.CreateBudgetLineCategoryParams) error
+	ListBudgetTransactions(context.Context, sqlc.ListBudgetTransactionsParams) ([]sqlc.ListBudgetTransactionsRow, error)
+	SumUncategorizedBudgetTransactions(context.Context, sqlc.SumUncategorizedBudgetTransactionsParams) (float32, error)
 }
 
 type TransactionService interface {

--- a/internal/app/test_fakes_test.go
+++ b/internal/app/test_fakes_test.go
@@ -43,10 +43,12 @@ type fakeRepo struct {
 	budgetLines             []sqlc.BudgetLine
 	budgetLineCategories    []sqlc.ListBudgetLineCategoriesRow
 
-	lastHouseholdBudgetPeriodStart time.Time
-	lastUserBudgetPeriodStart      time.Time
-	lastCreateHouseholdBudget      sqlc.CreateHouseholdBudgetParams
-	lastCreateUserBudget           sqlc.CreateUserBudgetParams
+	lastHouseholdBudgetPeriodStart       time.Time
+	lastUserBudgetPeriodStart            time.Time
+	lastCreateHouseholdBudget            sqlc.CreateHouseholdBudgetParams
+	lastCreateUserBudget                 sqlc.CreateUserBudgetParams
+	lastListBudgetLinesBudgetID          int64
+	lastListBudgetLineCategoriesBudgetID int64
 }
 
 func (f *fakeRepo) CreateUser(_ context.Context, arg sqlc.CreateUserParams) (sqlc.User, error) {
@@ -220,12 +222,26 @@ func (f *fakeRepo) GetLatestPriorUserBudget(context.Context, sqlc.GetLatestPrior
 	return f.latestPriorUser, nil
 }
 
-func (f *fakeRepo) ListBudgetLines(context.Context, int64) ([]sqlc.BudgetLine, error) {
-	return f.budgetLines, nil
+func (f *fakeRepo) ListBudgetLines(_ context.Context, budgetID int64) ([]sqlc.BudgetLine, error) {
+	f.lastListBudgetLinesBudgetID = budgetID
+	lines := make([]sqlc.BudgetLine, 0, len(f.budgetLines))
+	for _, line := range f.budgetLines {
+		if line.BudgetID == budgetID {
+			lines = append(lines, line)
+		}
+	}
+	return lines, nil
 }
 
-func (f *fakeRepo) ListBudgetLineCategories(context.Context, int64) ([]sqlc.ListBudgetLineCategoriesRow, error) {
-	return f.budgetLineCategories, nil
+func (f *fakeRepo) ListBudgetLineCategories(_ context.Context, budgetID int64) ([]sqlc.ListBudgetLineCategoriesRow, error) {
+	f.lastListBudgetLineCategoriesBudgetID = budgetID
+	categories := make([]sqlc.ListBudgetLineCategoriesRow, 0, len(f.budgetLineCategories))
+	for _, category := range f.budgetLineCategories {
+		if category.BudgetID == budgetID {
+			categories = append(categories, category)
+		}
+	}
+	return categories, nil
 }
 
 func (f *fakeRepo) GetBudgetLineById(context.Context, int64) (sqlc.BudgetLine, error) {

--- a/internal/app/test_fakes_test.go
+++ b/internal/app/test_fakes_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"database/sql"
+	"time"
 
 	"rdmm404/voltr-finance/internal/database/sqlc"
 	"rdmm404/voltr-finance/internal/transaction"
@@ -31,6 +32,21 @@ type fakeRepo struct {
 	categoryByID                      sqlc.Category
 	categoryByCode                    sqlc.Category
 	listCategoriesResult              []sqlc.Category
+
+	householdBudgetByPeriod sqlc.Budget
+	userBudgetByPeriod      sqlc.Budget
+	budgetByID              sqlc.Budget
+	latestPriorHousehold    sqlc.Budget
+	latestPriorUser         sqlc.Budget
+	createdHouseholdBudget  sqlc.Budget
+	createdUserBudget       sqlc.Budget
+	budgetLines             []sqlc.BudgetLine
+	budgetLineCategories    []sqlc.ListBudgetLineCategoriesRow
+
+	lastHouseholdBudgetPeriodStart time.Time
+	lastUserBudgetPeriodStart      time.Time
+	lastCreateHouseholdBudget      sqlc.CreateHouseholdBudgetParams
+	lastCreateUserBudget           sqlc.CreateUserBudgetParams
 }
 
 func (f *fakeRepo) CreateUser(_ context.Context, arg sqlc.CreateUserParams) (sqlc.User, error) {
@@ -165,6 +181,115 @@ func (f *fakeRepo) DeactivateCategory(context.Context, string) (sqlc.Category, e
 	}
 	f.categoryByCode.IsActive = false
 	return f.categoryByCode, nil
+}
+
+func (f *fakeRepo) GetHouseholdBudgetByPeriod(_ context.Context, arg sqlc.GetHouseholdBudgetByPeriodParams) (sqlc.Budget, error) {
+	f.lastHouseholdBudgetPeriodStart = arg.PeriodStart.Time
+	if f.householdBudgetByPeriod.ID == 0 {
+		return sqlc.Budget{}, sql.ErrNoRows
+	}
+	return f.householdBudgetByPeriod, nil
+}
+
+func (f *fakeRepo) GetUserBudgetByPeriod(_ context.Context, arg sqlc.GetUserBudgetByPeriodParams) (sqlc.Budget, error) {
+	f.lastUserBudgetPeriodStart = arg.PeriodStart.Time
+	if f.userBudgetByPeriod.ID == 0 {
+		return sqlc.Budget{}, sql.ErrNoRows
+	}
+	return f.userBudgetByPeriod, nil
+}
+
+func (f *fakeRepo) GetBudgetById(context.Context, int64) (sqlc.Budget, error) {
+	if f.budgetByID.ID == 0 {
+		return sqlc.Budget{}, sql.ErrNoRows
+	}
+	return f.budgetByID, nil
+}
+
+func (f *fakeRepo) GetLatestPriorHouseholdBudget(context.Context, sqlc.GetLatestPriorHouseholdBudgetParams) (sqlc.Budget, error) {
+	if f.latestPriorHousehold.ID == 0 {
+		return sqlc.Budget{}, sql.ErrNoRows
+	}
+	return f.latestPriorHousehold, nil
+}
+
+func (f *fakeRepo) GetLatestPriorUserBudget(context.Context, sqlc.GetLatestPriorUserBudgetParams) (sqlc.Budget, error) {
+	if f.latestPriorUser.ID == 0 {
+		return sqlc.Budget{}, sql.ErrNoRows
+	}
+	return f.latestPriorUser, nil
+}
+
+func (f *fakeRepo) ListBudgetLines(context.Context, int64) ([]sqlc.BudgetLine, error) {
+	return f.budgetLines, nil
+}
+
+func (f *fakeRepo) ListBudgetLineCategories(context.Context, int64) ([]sqlc.ListBudgetLineCategoriesRow, error) {
+	return f.budgetLineCategories, nil
+}
+
+func (f *fakeRepo) GetBudgetLineById(context.Context, int64) (sqlc.BudgetLine, error) {
+	return sqlc.BudgetLine{}, sql.ErrNoRows
+}
+
+func (f *fakeRepo) GetMaxBudgetLineSortOrder(context.Context, int64) (int32, error) {
+	return 0, nil
+}
+
+func (f *fakeRepo) CreateHouseholdBudget(_ context.Context, arg sqlc.CreateHouseholdBudgetParams) (sqlc.Budget, error) {
+	f.lastCreateHouseholdBudget = arg
+	if f.createdHouseholdBudget.ID != 0 {
+		return f.createdHouseholdBudget, nil
+	}
+	return sqlc.Budget{
+		ID:             1,
+		HouseholdID:    &arg.HouseholdID,
+		PeriodStart:    arg.PeriodStart,
+		PeriodEnd:      arg.PeriodEnd,
+		SourceBudgetID: arg.SourceBudgetID,
+	}, nil
+}
+
+func (f *fakeRepo) CreateUserBudget(_ context.Context, arg sqlc.CreateUserBudgetParams) (sqlc.Budget, error) {
+	f.lastCreateUserBudget = arg
+	if f.createdUserBudget.ID != 0 {
+		return f.createdUserBudget, nil
+	}
+	return sqlc.Budget{
+		ID:             1,
+		UserID:         &arg.UserID,
+		PeriodStart:    arg.PeriodStart,
+		PeriodEnd:      arg.PeriodEnd,
+		SourceBudgetID: arg.SourceBudgetID,
+	}, nil
+}
+
+func (f *fakeRepo) CreateBudgetLine(context.Context, sqlc.CreateBudgetLineParams) (sqlc.BudgetLine, error) {
+	return sqlc.BudgetLine{}, nil
+}
+
+func (f *fakeRepo) UpdateBudgetLine(context.Context, sqlc.UpdateBudgetLineParams) (sqlc.BudgetLine, error) {
+	return sqlc.BudgetLine{}, sql.ErrNoRows
+}
+
+func (f *fakeRepo) DeleteBudgetLine(context.Context, int64) error {
+	return nil
+}
+
+func (f *fakeRepo) DeleteBudgetLineCategories(context.Context, int64) error {
+	return nil
+}
+
+func (f *fakeRepo) CreateBudgetLineCategory(context.Context, sqlc.CreateBudgetLineCategoryParams) error {
+	return nil
+}
+
+func (f *fakeRepo) ListBudgetTransactions(context.Context, sqlc.ListBudgetTransactionsParams) ([]sqlc.ListBudgetTransactionsRow, error) {
+	return nil, nil
+}
+
+func (f *fakeRepo) SumUncategorizedBudgetTransactions(context.Context, sqlc.SumUncategorizedBudgetTransactionsParams) (float32, error) {
+	return 0, nil
 }
 
 type fakeTransactionService struct {

--- a/internal/app/test_fakes_test.go
+++ b/internal/app/test_fakes_test.go
@@ -45,6 +45,12 @@ type fakeRepo struct {
 	createdBudgetLines          []sqlc.CreateBudgetLineParams
 	createdBudgetLineRows       []sqlc.BudgetLine
 	createdBudgetLineCategories []sqlc.CreateBudgetLineCategoryParams
+	budgetLineByID              sqlc.BudgetLine
+	updatedBudgetLine           sqlc.BudgetLine
+	lastUpdateBudgetLine        sqlc.UpdateBudgetLineParams
+	maxSortOrder                int32
+	deletedBudgetLineID         int64
+	deletedBudgetLineCategoryID int64
 
 	lastHouseholdBudgetPeriodStart       time.Time
 	lastUserBudgetPeriodStart            time.Time
@@ -251,12 +257,15 @@ func (f *fakeRepo) ListBudgetLineCategories(_ context.Context, budgetID int64) (
 	return categories, nil
 }
 
-func (f *fakeRepo) GetBudgetLineById(context.Context, int64) (sqlc.BudgetLine, error) {
-	return sqlc.BudgetLine{}, sql.ErrNoRows
+func (f *fakeRepo) GetBudgetLineById(_ context.Context, id int64) (sqlc.BudgetLine, error) {
+	if f.budgetLineByID.ID == 0 || f.budgetLineByID.ID != id {
+		return sqlc.BudgetLine{}, sql.ErrNoRows
+	}
+	return f.budgetLineByID, nil
 }
 
 func (f *fakeRepo) GetMaxBudgetLineSortOrder(context.Context, int64) (int32, error) {
-	return 0, nil
+	return f.maxSortOrder, nil
 }
 
 func (f *fakeRepo) CreateHouseholdBudget(_ context.Context, arg sqlc.CreateHouseholdBudgetParams) (sqlc.Budget, error) {
@@ -305,15 +314,41 @@ func (f *fakeRepo) CreateBudgetLine(_ context.Context, arg sqlc.CreateBudgetLine
 	return row, nil
 }
 
-func (f *fakeRepo) UpdateBudgetLine(context.Context, sqlc.UpdateBudgetLineParams) (sqlc.BudgetLine, error) {
-	return sqlc.BudgetLine{}, sql.ErrNoRows
+func (f *fakeRepo) UpdateBudgetLine(_ context.Context, arg sqlc.UpdateBudgetLineParams) (sqlc.BudgetLine, error) {
+	f.lastUpdateBudgetLine = arg
+	if f.updatedBudgetLine.ID != 0 {
+		return f.updatedBudgetLine, nil
+	}
+	if f.budgetLineByID.ID == 0 {
+		return sqlc.BudgetLine{}, sql.ErrNoRows
+	}
+	line := f.budgetLineByID
+	if arg.SetName {
+		line.Name = arg.Name
+	}
+	if arg.SetAllocationAmount {
+		line.AllocationAmount = arg.AllocationAmount
+	}
+	if arg.SetSortOrder {
+		line.SortOrder = arg.SortOrder
+	}
+	return line, nil
 }
 
-func (f *fakeRepo) DeleteBudgetLine(context.Context, int64) error {
+func (f *fakeRepo) DeleteBudgetLine(_ context.Context, id int64) error {
+	f.deletedBudgetLineID = id
 	return nil
 }
 
-func (f *fakeRepo) DeleteBudgetLineCategories(context.Context, int64) error {
+func (f *fakeRepo) DeleteBudgetLineCategories(_ context.Context, id int64) error {
+	f.deletedBudgetLineCategoryID = id
+	filtered := f.budgetLineCategories[:0]
+	for _, category := range f.budgetLineCategories {
+		if category.BudgetLineID != id {
+			filtered = append(filtered, category)
+		}
+	}
+	f.budgetLineCategories = filtered
 	return nil
 }
 
@@ -321,6 +356,14 @@ func (f *fakeRepo) CreateBudgetLineCategory(_ context.Context, arg sqlc.CreateBu
 	f.createdBudgetLineCategories = append(f.createdBudgetLineCategories, arg)
 	categoryCode := ""
 	categoryName := ""
+	if f.categoryByID.ID == arg.CategoryID {
+		categoryCode = f.categoryByID.Code
+		categoryName = f.categoryByID.Name
+	}
+	if f.categoryByCode.ID == arg.CategoryID {
+		categoryCode = f.categoryByCode.Code
+		categoryName = f.categoryByCode.Name
+	}
 	for _, category := range f.budgetLineCategories {
 		if category.CategoryID == arg.CategoryID {
 			categoryCode = category.CategoryCode

--- a/internal/app/test_fakes_test.go
+++ b/internal/app/test_fakes_test.go
@@ -33,20 +33,25 @@ type fakeRepo struct {
 	categoryByCode                    sqlc.Category
 	listCategoriesResult              []sqlc.Category
 
-	householdBudgetByPeriod sqlc.Budget
-	userBudgetByPeriod      sqlc.Budget
-	budgetByID              sqlc.Budget
-	latestPriorHousehold    sqlc.Budget
-	latestPriorUser         sqlc.Budget
-	createdHouseholdBudget  sqlc.Budget
-	createdUserBudget       sqlc.Budget
-	budgetLines             []sqlc.BudgetLine
-	budgetLineCategories    []sqlc.ListBudgetLineCategoriesRow
+	householdBudgetByPeriod     sqlc.Budget
+	userBudgetByPeriod          sqlc.Budget
+	budgetByID                  sqlc.Budget
+	latestPriorHousehold        sqlc.Budget
+	latestPriorUser             sqlc.Budget
+	createdHouseholdBudget      sqlc.Budget
+	createdUserBudget           sqlc.Budget
+	budgetLines                 []sqlc.BudgetLine
+	budgetLineCategories        []sqlc.ListBudgetLineCategoriesRow
+	createdBudgetLines          []sqlc.CreateBudgetLineParams
+	createdBudgetLineRows       []sqlc.BudgetLine
+	createdBudgetLineCategories []sqlc.CreateBudgetLineCategoryParams
 
 	lastHouseholdBudgetPeriodStart       time.Time
 	lastUserBudgetPeriodStart            time.Time
 	lastCreateHouseholdBudget            sqlc.CreateHouseholdBudgetParams
 	lastCreateUserBudget                 sqlc.CreateUserBudgetParams
+	lastLatestPriorHouseholdBudget       sqlc.GetLatestPriorHouseholdBudgetParams
+	lastLatestPriorUserBudget            sqlc.GetLatestPriorUserBudgetParams
 	lastListBudgetLinesBudgetID          int64
 	lastListBudgetLineCategoriesBudgetID int64
 }
@@ -208,14 +213,16 @@ func (f *fakeRepo) GetBudgetById(context.Context, int64) (sqlc.Budget, error) {
 	return f.budgetByID, nil
 }
 
-func (f *fakeRepo) GetLatestPriorHouseholdBudget(context.Context, sqlc.GetLatestPriorHouseholdBudgetParams) (sqlc.Budget, error) {
+func (f *fakeRepo) GetLatestPriorHouseholdBudget(_ context.Context, arg sqlc.GetLatestPriorHouseholdBudgetParams) (sqlc.Budget, error) {
+	f.lastLatestPriorHouseholdBudget = arg
 	if f.latestPriorHousehold.ID == 0 {
 		return sqlc.Budget{}, sql.ErrNoRows
 	}
 	return f.latestPriorHousehold, nil
 }
 
-func (f *fakeRepo) GetLatestPriorUserBudget(context.Context, sqlc.GetLatestPriorUserBudgetParams) (sqlc.Budget, error) {
+func (f *fakeRepo) GetLatestPriorUserBudget(_ context.Context, arg sqlc.GetLatestPriorUserBudgetParams) (sqlc.Budget, error) {
+	f.lastLatestPriorUserBudget = arg
 	if f.latestPriorUser.ID == 0 {
 		return sqlc.Budget{}, sql.ErrNoRows
 	}
@@ -280,8 +287,22 @@ func (f *fakeRepo) CreateUserBudget(_ context.Context, arg sqlc.CreateUserBudget
 	}, nil
 }
 
-func (f *fakeRepo) CreateBudgetLine(context.Context, sqlc.CreateBudgetLineParams) (sqlc.BudgetLine, error) {
-	return sqlc.BudgetLine{}, nil
+func (f *fakeRepo) CreateBudgetLine(_ context.Context, arg sqlc.CreateBudgetLineParams) (sqlc.BudgetLine, error) {
+	f.createdBudgetLines = append(f.createdBudgetLines, arg)
+	if len(f.createdBudgetLineRows) >= len(f.createdBudgetLines) {
+		row := f.createdBudgetLineRows[len(f.createdBudgetLines)-1]
+		f.budgetLines = append(f.budgetLines, row)
+		return row, nil
+	}
+	row := sqlc.BudgetLine{
+		ID:               int64(len(f.createdBudgetLines)),
+		BudgetID:         arg.BudgetID,
+		Name:             arg.Name,
+		AllocationAmount: arg.AllocationAmount,
+		SortOrder:        arg.SortOrder,
+	}
+	f.budgetLines = append(f.budgetLines, row)
+	return row, nil
 }
 
 func (f *fakeRepo) UpdateBudgetLine(context.Context, sqlc.UpdateBudgetLineParams) (sqlc.BudgetLine, error) {
@@ -296,7 +317,15 @@ func (f *fakeRepo) DeleteBudgetLineCategories(context.Context, int64) error {
 	return nil
 }
 
-func (f *fakeRepo) CreateBudgetLineCategory(context.Context, sqlc.CreateBudgetLineCategoryParams) error {
+func (f *fakeRepo) CreateBudgetLineCategory(_ context.Context, arg sqlc.CreateBudgetLineCategoryParams) error {
+	f.createdBudgetLineCategories = append(f.createdBudgetLineCategories, arg)
+	f.budgetLineCategories = append(f.budgetLineCategories, sqlc.ListBudgetLineCategoriesRow{
+		BudgetID:     arg.BudgetID,
+		BudgetLineID: arg.BudgetLineID,
+		CategoryID:   arg.CategoryID,
+		CategoryCode: "",
+		CategoryName: "",
+	})
 	return nil
 }
 

--- a/internal/app/test_fakes_test.go
+++ b/internal/app/test_fakes_test.go
@@ -319,12 +319,21 @@ func (f *fakeRepo) DeleteBudgetLineCategories(context.Context, int64) error {
 
 func (f *fakeRepo) CreateBudgetLineCategory(_ context.Context, arg sqlc.CreateBudgetLineCategoryParams) error {
 	f.createdBudgetLineCategories = append(f.createdBudgetLineCategories, arg)
+	categoryCode := ""
+	categoryName := ""
+	for _, category := range f.budgetLineCategories {
+		if category.CategoryID == arg.CategoryID {
+			categoryCode = category.CategoryCode
+			categoryName = category.CategoryName
+			break
+		}
+	}
 	f.budgetLineCategories = append(f.budgetLineCategories, sqlc.ListBudgetLineCategoriesRow{
 		BudgetID:     arg.BudgetID,
 		BudgetLineID: arg.BudgetLineID,
 		CategoryID:   arg.CategoryID,
-		CategoryCode: "",
-		CategoryName: "",
+		CategoryCode: categoryCode,
+		CategoryName: categoryName,
 	})
 	return nil
 }
@@ -335,6 +344,16 @@ func (f *fakeRepo) ListBudgetTransactions(context.Context, sqlc.ListBudgetTransa
 
 func (f *fakeRepo) SumUncategorizedBudgetTransactions(context.Context, sqlc.SumUncategorizedBudgetTransactionsParams) (float32, error) {
 	return 0, nil
+}
+
+type fakeTransactor struct {
+	repo  Repository
+	calls int
+}
+
+func (f *fakeTransactor) WithinTx(ctx context.Context, fn func(Repository) error) error {
+	f.calls++
+	return fn(f.repo)
 }
 
 type fakeTransactionService struct {

--- a/internal/app/test_fakes_test.go
+++ b/internal/app/test_fakes_test.go
@@ -33,33 +33,37 @@ type fakeRepo struct {
 	categoryByCode                    sqlc.Category
 	listCategoriesResult              []sqlc.Category
 
-	householdBudgetByPeriod     sqlc.Budget
-	userBudgetByPeriod          sqlc.Budget
-	budgetByID                  sqlc.Budget
-	latestPriorHousehold        sqlc.Budget
-	latestPriorUser             sqlc.Budget
-	createdHouseholdBudget      sqlc.Budget
-	createdUserBudget           sqlc.Budget
-	budgetLines                 []sqlc.BudgetLine
-	budgetLineCategories        []sqlc.ListBudgetLineCategoriesRow
-	createdBudgetLines          []sqlc.CreateBudgetLineParams
-	createdBudgetLineRows       []sqlc.BudgetLine
-	createdBudgetLineCategories []sqlc.CreateBudgetLineCategoryParams
-	budgetLineByID              sqlc.BudgetLine
-	updatedBudgetLine           sqlc.BudgetLine
-	lastUpdateBudgetLine        sqlc.UpdateBudgetLineParams
-	maxSortOrder                int32
-	deletedBudgetLineID         int64
-	deletedBudgetLineCategoryID int64
+	householdBudgetByPeriod         sqlc.Budget
+	userBudgetByPeriod              sqlc.Budget
+	budgetByID                      sqlc.Budget
+	latestPriorHousehold            sqlc.Budget
+	latestPriorUser                 sqlc.Budget
+	createdHouseholdBudget          sqlc.Budget
+	createdUserBudget               sqlc.Budget
+	budgetLines                     []sqlc.BudgetLine
+	budgetLineCategories            []sqlc.ListBudgetLineCategoriesRow
+	createdBudgetLines              []sqlc.CreateBudgetLineParams
+	createdBudgetLineRows           []sqlc.BudgetLine
+	createdBudgetLineCategories     []sqlc.CreateBudgetLineCategoryParams
+	budgetLineByID                  sqlc.BudgetLine
+	updatedBudgetLine               sqlc.BudgetLine
+	lastUpdateBudgetLine            sqlc.UpdateBudgetLineParams
+	maxSortOrder                    int32
+	deletedBudgetLineID             int64
+	deletedBudgetLineCategoryID     int64
+	budgetTransactions              []sqlc.ListBudgetTransactionsRow
+	uncategorizedBudgetTransactions float32
 
-	lastHouseholdBudgetPeriodStart       time.Time
-	lastUserBudgetPeriodStart            time.Time
-	lastCreateHouseholdBudget            sqlc.CreateHouseholdBudgetParams
-	lastCreateUserBudget                 sqlc.CreateUserBudgetParams
-	lastLatestPriorHouseholdBudget       sqlc.GetLatestPriorHouseholdBudgetParams
-	lastLatestPriorUserBudget            sqlc.GetLatestPriorUserBudgetParams
-	lastListBudgetLinesBudgetID          int64
-	lastListBudgetLineCategoriesBudgetID int64
+	lastHouseholdBudgetPeriodStart         time.Time
+	lastUserBudgetPeriodStart              time.Time
+	lastCreateHouseholdBudget              sqlc.CreateHouseholdBudgetParams
+	lastCreateUserBudget                   sqlc.CreateUserBudgetParams
+	lastLatestPriorHouseholdBudget         sqlc.GetLatestPriorHouseholdBudgetParams
+	lastLatestPriorUserBudget              sqlc.GetLatestPriorUserBudgetParams
+	lastListBudgetLinesBudgetID            int64
+	lastListBudgetLineCategoriesBudgetID   int64
+	lastListBudgetTransactions             sqlc.ListBudgetTransactionsParams
+	lastSumUncategorizedBudgetTransactions sqlc.SumUncategorizedBudgetTransactionsParams
 }
 
 func (f *fakeRepo) CreateUser(_ context.Context, arg sqlc.CreateUserParams) (sqlc.User, error) {
@@ -381,12 +385,14 @@ func (f *fakeRepo) CreateBudgetLineCategory(_ context.Context, arg sqlc.CreateBu
 	return nil
 }
 
-func (f *fakeRepo) ListBudgetTransactions(context.Context, sqlc.ListBudgetTransactionsParams) ([]sqlc.ListBudgetTransactionsRow, error) {
-	return nil, nil
+func (f *fakeRepo) ListBudgetTransactions(_ context.Context, arg sqlc.ListBudgetTransactionsParams) ([]sqlc.ListBudgetTransactionsRow, error) {
+	f.lastListBudgetTransactions = arg
+	return f.budgetTransactions, nil
 }
 
-func (f *fakeRepo) SumUncategorizedBudgetTransactions(context.Context, sqlc.SumUncategorizedBudgetTransactionsParams) (float32, error) {
-	return 0, nil
+func (f *fakeRepo) SumUncategorizedBudgetTransactions(_ context.Context, arg sqlc.SumUncategorizedBudgetTransactionsParams) (float32, error) {
+	f.lastSumUncategorizedBudgetTransactions = arg
+	return f.uncategorizedBudgetTransactions, nil
 }
 
 type fakeTransactor struct {

--- a/internal/app/test_fakes_test.go
+++ b/internal/app/test_fakes_test.go
@@ -3,7 +3,10 @@ package app
 import (
 	"context"
 	"database/sql"
+	"math/big"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"rdmm404/voltr-finance/internal/database/sqlc"
 	"rdmm404/voltr-finance/internal/transaction"
@@ -34,7 +37,9 @@ type fakeRepo struct {
 	listCategoriesResult              []sqlc.Category
 
 	householdBudgetByPeriod         sqlc.Budget
+	householdBudgetByPeriodMisses   int
 	userBudgetByPeriod              sqlc.Budget
+	userBudgetByPeriodMisses        int
 	budgetByID                      sqlc.Budget
 	latestPriorHousehold            sqlc.Budget
 	latestPriorUser                 sqlc.Budget
@@ -51,8 +56,10 @@ type fakeRepo struct {
 	maxSortOrder                    int32
 	deletedBudgetLineID             int64
 	deletedBudgetLineCategoryID     int64
-	budgetTransactions              []sqlc.ListBudgetTransactionsRow
-	uncategorizedBudgetTransactions float32
+	budgetReportLines               []sqlc.ListBudgetReportLinesRow
+	uncategorizedBudgetTransactions pgtype.Numeric
+	createHouseholdBudgetErr        error
+	createUserBudgetErr             error
 
 	lastHouseholdBudgetPeriodStart         time.Time
 	lastUserBudgetPeriodStart              time.Time
@@ -62,8 +69,8 @@ type fakeRepo struct {
 	lastLatestPriorUserBudget              sqlc.GetLatestPriorUserBudgetParams
 	lastListBudgetLinesBudgetID            int64
 	lastListBudgetLineCategoriesBudgetID   int64
-	lastListBudgetTransactions             sqlc.ListBudgetTransactionsParams
-	lastSumUncategorizedBudgetTransactions sqlc.SumUncategorizedBudgetTransactionsParams
+	lastListBudgetReportLinesBudgetID      int64
+	lastSumUncategorizedBudgetTransactions int64
 }
 
 func (f *fakeRepo) CreateUser(_ context.Context, arg sqlc.CreateUserParams) (sqlc.User, error) {
@@ -202,6 +209,10 @@ func (f *fakeRepo) DeactivateCategory(context.Context, string) (sqlc.Category, e
 
 func (f *fakeRepo) GetHouseholdBudgetByPeriod(_ context.Context, arg sqlc.GetHouseholdBudgetByPeriodParams) (sqlc.Budget, error) {
 	f.lastHouseholdBudgetPeriodStart = arg.PeriodStart.Time
+	if f.householdBudgetByPeriodMisses > 0 {
+		f.householdBudgetByPeriodMisses--
+		return sqlc.Budget{}, sql.ErrNoRows
+	}
 	if f.householdBudgetByPeriod.ID == 0 {
 		return sqlc.Budget{}, sql.ErrNoRows
 	}
@@ -210,6 +221,10 @@ func (f *fakeRepo) GetHouseholdBudgetByPeriod(_ context.Context, arg sqlc.GetHou
 
 func (f *fakeRepo) GetUserBudgetByPeriod(_ context.Context, arg sqlc.GetUserBudgetByPeriodParams) (sqlc.Budget, error) {
 	f.lastUserBudgetPeriodStart = arg.PeriodStart.Time
+	if f.userBudgetByPeriodMisses > 0 {
+		f.userBudgetByPeriodMisses--
+		return sqlc.Budget{}, sql.ErrNoRows
+	}
 	if f.userBudgetByPeriod.ID == 0 {
 		return sqlc.Budget{}, sql.ErrNoRows
 	}
@@ -274,6 +289,9 @@ func (f *fakeRepo) GetMaxBudgetLineSortOrder(context.Context, int64) (int32, err
 
 func (f *fakeRepo) CreateHouseholdBudget(_ context.Context, arg sqlc.CreateHouseholdBudgetParams) (sqlc.Budget, error) {
 	f.lastCreateHouseholdBudget = arg
+	if f.createHouseholdBudgetErr != nil {
+		return sqlc.Budget{}, f.createHouseholdBudgetErr
+	}
 	if f.createdHouseholdBudget.ID != 0 {
 		return f.createdHouseholdBudget, nil
 	}
@@ -288,6 +306,9 @@ func (f *fakeRepo) CreateHouseholdBudget(_ context.Context, arg sqlc.CreateHouse
 
 func (f *fakeRepo) CreateUserBudget(_ context.Context, arg sqlc.CreateUserBudgetParams) (sqlc.Budget, error) {
 	f.lastCreateUserBudget = arg
+	if f.createUserBudgetErr != nil {
+		return sqlc.Budget{}, f.createUserBudgetErr
+	}
 	if f.createdUserBudget.ID != 0 {
 		return f.createdUserBudget, nil
 	}
@@ -385,14 +406,34 @@ func (f *fakeRepo) CreateBudgetLineCategory(_ context.Context, arg sqlc.CreateBu
 	return nil
 }
 
-func (f *fakeRepo) ListBudgetTransactions(_ context.Context, arg sqlc.ListBudgetTransactionsParams) ([]sqlc.ListBudgetTransactionsRow, error) {
-	f.lastListBudgetTransactions = arg
-	return f.budgetTransactions, nil
+func (f *fakeRepo) ListBudgetReportLines(_ context.Context, budgetID int64) ([]sqlc.ListBudgetReportLinesRow, error) {
+	f.lastListBudgetReportLinesBudgetID = budgetID
+	if f.budgetReportLines != nil {
+		return f.budgetReportLines, nil
+	}
+	lines := make([]sqlc.ListBudgetReportLinesRow, 0, len(f.budgetLines))
+	for _, line := range f.budgetLines {
+		if line.BudgetID != budgetID {
+			continue
+		}
+		lines = append(lines, sqlc.ListBudgetReportLinesRow{
+			ID:               line.ID,
+			BudgetID:         line.BudgetID,
+			Name:             line.Name,
+			AllocationAmount: line.AllocationAmount,
+			ActualAmount:     pgtype.Numeric{Int: big.NewInt(0), Exp: -2, Valid: true},
+			SortOrder:        line.SortOrder,
+		})
+	}
+	return lines, nil
 }
 
-func (f *fakeRepo) SumUncategorizedBudgetTransactions(_ context.Context, arg sqlc.SumUncategorizedBudgetTransactionsParams) (float32, error) {
-	f.lastSumUncategorizedBudgetTransactions = arg
-	return f.uncategorizedBudgetTransactions, nil
+func (f *fakeRepo) SumUncategorizedBudgetTransactions(_ context.Context, budgetID int64) (pgtype.Numeric, error) {
+	f.lastSumUncategorizedBudgetTransactions = budgetID
+	if f.uncategorizedBudgetTransactions.Valid {
+		return f.uncategorizedBudgetTransactions, nil
+	}
+	return pgtype.Numeric{Int: big.NewInt(0), Exp: -2, Valid: true}, nil
 }
 
 type fakeTransactor struct {

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -41,6 +41,12 @@ type AppService interface {
 	GetCategoryByCode(context.Context, string) (app.CategoryDTO, error)
 	UpdateCategory(context.Context, app.UpdateCategoryRequest) (app.CategoryDTO, error)
 	DeactivateCategory(context.Context, string) (app.CategoryDTO, error)
+
+	GetMonthlyBudget(context.Context, app.GetMonthlyBudgetRequest) (app.BudgetDTO, error)
+	CreateBudgetLine(context.Context, app.CreateBudgetLineRequest) (app.BudgetLineDTO, error)
+	UpdateBudgetLine(context.Context, app.UpdateBudgetLineRequest) (app.BudgetLineDTO, error)
+	DeleteBudgetLine(context.Context, int64) error
+	GetBudgetReport(context.Context, int64) (app.BudgetReportDTO, error)
 }
 
 type CLI struct {
@@ -48,6 +54,7 @@ type CLI struct {
 	Users        UsersCmd        `cmd:"" help:"Manage users."`
 	Households   HouseholdsCmd   `cmd:"" help:"Read households."`
 	Categories   CategoriesCmd   `cmd:"" help:"Manage transaction categories."`
+	Budgets      BudgetsCmd      `cmd:"" help:"Manage budgets."`
 }
 
 type runContext struct {
@@ -490,6 +497,112 @@ func (c *HouseholdUsersCmd) Run(ctx *runContext) error {
 	return RenderJSON(ctx.stdout, users)
 }
 
+type BudgetsCmd struct {
+	Get    BudgetGetCmd    `cmd:"" help:"Get a monthly budget."`
+	Report BudgetReportCmd `cmd:"" help:"Show a budget report."`
+	Lines  BudgetLinesCmd  `cmd:"" help:"Manage budget lines."`
+}
+
+type BudgetGetCmd struct {
+	HouseholdID *int64 `placeholder:"INT-64" help:"Household budget owner."`
+	UserID      *int64 `placeholder:"INT-64" help:"Personal budget owner."`
+	Month       string `required:"" help:"Budget month in YYYY-MM format."`
+	Create      bool   `help:"Create the monthly budget if missing."`
+}
+
+func (c *BudgetGetCmd) Run(ctx *runContext) error {
+	year, month, err := parseBudgetMonth(c.Month)
+	if err != nil {
+		return err
+	}
+	budget, err := ctx.svc.GetMonthlyBudget(ctx.Context, app.GetMonthlyBudgetRequest{
+		HouseholdID:     c.HouseholdID,
+		UserID:          c.UserID,
+		Year:            year,
+		Month:           month,
+		CreateIfMissing: c.Create,
+	})
+	if err != nil {
+		return err
+	}
+	return RenderJSON(ctx.stdout, budget)
+}
+
+type BudgetReportCmd struct {
+	ID int64 `arg:"" required:"" help:"Budget ID."`
+}
+
+func (c *BudgetReportCmd) Run(ctx *runContext) error {
+	report, err := ctx.svc.GetBudgetReport(ctx.Context, c.ID)
+	if err != nil {
+		return err
+	}
+	return RenderJSON(ctx.stdout, report)
+}
+
+type BudgetLinesCmd struct {
+	Add    BudgetLineAddCmd    `cmd:"" help:"Add a budget line."`
+	Update BudgetLineUpdateCmd `cmd:"" help:"Update a budget line."`
+	Delete BudgetLineDeleteCmd `cmd:"" help:"Delete a budget line."`
+}
+
+type BudgetLineAddCmd struct {
+	BudgetID   int64   `required:"" placeholder:"INT-64" help:"Budget ID."`
+	Name       string  `required:"" help:"Budget line name."`
+	Amount     string  `required:"" help:"Allocation amount."`
+	Categories *string `help:"Comma-separated category codes."`
+	SortOrder  *int32  `help:"Display sort order."`
+}
+
+func (c *BudgetLineAddCmd) Run(ctx *runContext) error {
+	line, err := ctx.svc.CreateBudgetLine(ctx.Context, app.CreateBudgetLineRequest{
+		BudgetID:         c.BudgetID,
+		Name:             c.Name,
+		AllocationAmount: c.Amount,
+		CategoryCodes:    parseOptionalCSV(c.Categories),
+		SortOrder:        c.SortOrder,
+	})
+	if err != nil {
+		return err
+	}
+	return RenderJSON(ctx.stdout, line)
+}
+
+type BudgetLineUpdateCmd struct {
+	ID         int64   `arg:"" required:"" help:"Budget line ID."`
+	Name       *string `help:"Replacement budget line name."`
+	Amount     *string `help:"Replacement allocation amount."`
+	Categories *string `help:"Replacement comma-separated category codes."`
+	SortOrder  *int32  `help:"Replacement display sort order."`
+}
+
+func (c *BudgetLineUpdateCmd) Run(ctx *runContext) error {
+	var categoryCodes *[]string
+	if c.Categories != nil {
+		parsed := parseOptionalCSV(c.Categories)
+		categoryCodes = &parsed
+	}
+	line, err := ctx.svc.UpdateBudgetLine(ctx.Context, app.UpdateBudgetLineRequest{
+		LineID:           c.ID,
+		Name:             c.Name,
+		AllocationAmount: c.Amount,
+		CategoryCodes:    categoryCodes,
+		SortOrder:        c.SortOrder,
+	})
+	if err != nil {
+		return err
+	}
+	return RenderJSON(ctx.stdout, line)
+}
+
+type BudgetLineDeleteCmd struct {
+	ID int64 `arg:"" required:"" help:"Budget line ID."`
+}
+
+func (c *BudgetLineDeleteCmd) Run(ctx *runContext) error {
+	return ctx.svc.DeleteBudgetLine(ctx.Context, c.ID)
+}
+
 func identity(authorID *int64, discordID, telegramID, phoneNumber, whatsappID *string) app.IdentitySelector {
 	return app.IdentitySelector{AuthorID: authorID, DiscordID: discordID, TelegramID: telegramID, PhoneNumber: phoneNumber, WhatsappID: whatsappID}
 }
@@ -557,6 +670,29 @@ func parseIDs(raw string) ([]int64, error) {
 		ids = append(ids, id)
 	}
 	return ids, nil
+}
+
+func parseBudgetMonth(value string) (int, int, error) {
+	parsed, err := time.Parse("2006-01", value)
+	if err != nil {
+		return 0, 0, fmt.Errorf("month must be in YYYY-MM format")
+	}
+	return parsed.Year(), int(parsed.Month()), nil
+}
+
+func parseOptionalCSV(value *string) []string {
+	if value == nil || strings.TrimSpace(*value) == "" {
+		return nil
+	}
+	parts := strings.Split(*value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
 }
 
 func isHelpArgs(args []string) bool {

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -179,6 +179,90 @@ func TestKongHouseholdsGetByName(t *testing.T) {
 	}
 }
 
+func TestKongBudgetsGetHouseholdCreate(t *testing.T) {
+	svc := &fakeAppService{}
+	code := Run(context.Background(), []string{
+		"budgets", "get",
+		"--household-id", "1",
+		"--month", "2026-05",
+		"--create",
+	}, nil, &bytes.Buffer{}, &bytes.Buffer{}, svc)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if svc.getMonthlyBudget.HouseholdID == nil || *svc.getMonthlyBudget.HouseholdID != 1 {
+		t.Fatalf("HouseholdID = %v, want 1", svc.getMonthlyBudget.HouseholdID)
+	}
+	if svc.getMonthlyBudget.Year != 2026 || svc.getMonthlyBudget.Month != 5 || !svc.getMonthlyBudget.CreateIfMissing {
+		t.Fatalf("getMonthlyBudget = %+v, want May 2026 create", svc.getMonthlyBudget)
+	}
+}
+
+func TestKongBudgetsReport(t *testing.T) {
+	svc := &fakeAppService{}
+	code := Run(context.Background(), []string{
+		"budgets", "report", "12",
+	}, nil, &bytes.Buffer{}, &bytes.Buffer{}, svc)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if svc.getBudgetReportID != 12 {
+		t.Fatalf("report id = %d, want 12", svc.getBudgetReportID)
+	}
+}
+
+func TestKongBudgetLinesAdd(t *testing.T) {
+	svc := &fakeAppService{}
+	code := Run(context.Background(), []string{
+		"budgets", "lines", "add",
+		"--budget-id", "12",
+		"--name", "Groceries",
+		"--amount", "800.00",
+		"--categories", "groceries,costco",
+	}, nil, &bytes.Buffer{}, &bytes.Buffer{}, svc)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if svc.createBudgetLine.BudgetID != 12 || svc.createBudgetLine.Name != "Groceries" {
+		t.Fatalf("createBudgetLine = %+v, want budget 12 groceries", svc.createBudgetLine)
+	}
+	if len(svc.createBudgetLine.CategoryCodes) != 2 || svc.createBudgetLine.CategoryCodes[1] != "costco" {
+		t.Fatalf("CategoryCodes = %v, want groceries,costco", svc.createBudgetLine.CategoryCodes)
+	}
+}
+
+func TestKongBudgetLinesUpdateUsesPositionalLineID(t *testing.T) {
+	svc := &fakeAppService{}
+	code := Run(context.Background(), []string{
+		"budgets", "lines", "update", "44",
+		"--amount", "900.00",
+	}, nil, &bytes.Buffer{}, &bytes.Buffer{}, svc)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if svc.updateBudgetLine.LineID != 44 || svc.updateBudgetLine.AllocationAmount == nil || *svc.updateBudgetLine.AllocationAmount != "900.00" {
+		t.Fatalf("updateBudgetLine = %+v, want line 44 amount 900.00", svc.updateBudgetLine)
+	}
+}
+
+func TestKongBudgetLinesDeleteUsesPositionalLineID(t *testing.T) {
+	svc := &fakeAppService{}
+	code := Run(context.Background(), []string{
+		"budgets", "lines", "delete", "44",
+	}, nil, &bytes.Buffer{}, &bytes.Buffer{}, svc)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if svc.deleteBudgetLineID != 44 {
+		t.Fatalf("deleteBudgetLineID = %d, want 44", svc.deleteBudgetLineID)
+	}
+}
+
 func TestKongSubcommandHelpDoesNotPanicWithoutService(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
@@ -302,6 +386,11 @@ type fakeAppService struct {
 	listCategories         app.ListCategoriesRequest
 	updateCategory         app.UpdateCategoryRequest
 	deactivateCategoryCode string
+	getMonthlyBudget       app.GetMonthlyBudgetRequest
+	createBudgetLine       app.CreateBudgetLineRequest
+	updateBudgetLine       app.UpdateBudgetLineRequest
+	deleteBudgetLineID     int64
+	getBudgetReportID      int64
 }
 
 func (f *fakeAppService) CreateTransaction(_ context.Context, req app.CreateTransactionRequest) app.WriteResult {
@@ -407,4 +496,33 @@ func (f *fakeAppService) UpdateCategory(_ context.Context, req app.UpdateCategor
 func (f *fakeAppService) DeactivateCategory(_ context.Context, code string) (app.CategoryDTO, error) {
 	f.deactivateCategoryCode = code
 	return app.CategoryDTO{ID: 1, Code: code, Name: "Groceries", IsActive: false}, nil
+}
+
+func (f *fakeAppService) GetMonthlyBudget(_ context.Context, req app.GetMonthlyBudgetRequest) (app.BudgetDTO, error) {
+	f.getMonthlyBudget = req
+	return app.BudgetDTO{ID: 12}, nil
+}
+
+func (f *fakeAppService) CreateBudgetLine(_ context.Context, req app.CreateBudgetLineRequest) (app.BudgetLineDTO, error) {
+	f.createBudgetLine = req
+	return app.BudgetLineDTO{ID: 44, BudgetID: req.BudgetID, Name: req.Name, AllocationAmount: req.AllocationAmount}, nil
+}
+
+func (f *fakeAppService) UpdateBudgetLine(_ context.Context, req app.UpdateBudgetLineRequest) (app.BudgetLineDTO, error) {
+	f.updateBudgetLine = req
+	amount := ""
+	if req.AllocationAmount != nil {
+		amount = *req.AllocationAmount
+	}
+	return app.BudgetLineDTO{ID: req.LineID, AllocationAmount: amount}, nil
+}
+
+func (f *fakeAppService) DeleteBudgetLine(_ context.Context, id int64) error {
+	f.deleteBudgetLineID = id
+	return nil
+}
+
+func (f *fakeAppService) GetBudgetReport(_ context.Context, id int64) (app.BudgetReportDTO, error) {
+	f.getBudgetReportID = id
+	return app.BudgetReportDTO{}, nil
 }

--- a/internal/database/query.sql
+++ b/internal/database/query.sql
@@ -53,6 +53,168 @@ SET is_active = false,
 WHERE code = $1
 RETURNING *;
 
+-- ******************* budget *******************
+-- READS
+
+-- name: GetHouseholdBudgetByPeriod :one
+SELECT * FROM budget
+WHERE household_id = sqlc.arg(household_id)::BIGINT
+  AND user_id IS NULL
+  AND period_start = sqlc.arg(period_start)::DATE
+  AND period_end = sqlc.arg(period_end)::DATE;
+
+-- name: GetUserBudgetByPeriod :one
+SELECT * FROM budget
+WHERE user_id = sqlc.arg(user_id)::BIGINT
+  AND household_id IS NULL
+  AND period_start = sqlc.arg(period_start)::DATE
+  AND period_end = sqlc.arg(period_end)::DATE;
+
+-- name: GetBudgetById :one
+SELECT * FROM budget
+WHERE id = sqlc.arg(id)::BIGINT;
+
+-- name: GetLatestPriorHouseholdBudget :one
+SELECT * FROM budget
+WHERE household_id = sqlc.arg(household_id)::BIGINT
+  AND user_id IS NULL
+  AND period_start < sqlc.arg(period_start)::DATE
+ORDER BY period_start DESC, id DESC
+LIMIT 1;
+
+-- name: GetLatestPriorUserBudget :one
+SELECT * FROM budget
+WHERE user_id = sqlc.arg(user_id)::BIGINT
+  AND household_id IS NULL
+  AND period_start < sqlc.arg(period_start)::DATE
+ORDER BY period_start DESC, id DESC
+LIMIT 1;
+
+-- name: ListBudgetLines :many
+SELECT * FROM budget_line
+WHERE budget_id = sqlc.arg(budget_id)::BIGINT
+ORDER BY sort_order ASC, id ASC;
+
+-- name: ListBudgetLineCategories :many
+SELECT
+    blc.budget_id,
+    blc.budget_line_id,
+    blc.category_id,
+    c.code AS category_code,
+    c.name AS category_name
+FROM budget_line_category blc
+JOIN category c ON c.id = blc.category_id
+WHERE blc.budget_id = sqlc.arg(budget_id)::BIGINT
+ORDER BY blc.budget_line_id ASC, c.name ASC, c.id ASC;
+
+-- name: GetBudgetLineById :one
+SELECT * FROM budget_line
+WHERE id = sqlc.arg(id)::BIGINT;
+
+-- name: GetMaxBudgetLineSortOrder :one
+SELECT COALESCE(MAX(sort_order), 0)::INTEGER AS sort_order
+FROM budget_line
+WHERE budget_id = sqlc.arg(budget_id)::BIGINT;
+
+-- name: ListBudgetTransactions :many
+SELECT
+    t.category_id::BIGINT AS category_id,
+    SUM(t.amount)::REAL AS actual_amount
+FROM transaction t
+WHERE t.deleted_at IS NULL
+  AND t.category_id IS NOT NULL
+  AND t.transaction_date >= sqlc.arg(period_start)::DATE
+  AND t.transaction_date < (sqlc.arg(period_end)::DATE + INTERVAL '1 day')
+  AND (
+      (sqlc.narg(household_id)::BIGINT IS NOT NULL AND t.household_id = sqlc.narg(household_id)::BIGINT)
+      OR
+      (sqlc.narg(user_id)::BIGINT IS NOT NULL AND t.author_id = sqlc.narg(user_id)::BIGINT)
+  )
+GROUP BY t.category_id
+ORDER BY t.category_id ASC;
+
+-- name: SumUncategorizedBudgetTransactions :one
+SELECT COALESCE(SUM(t.amount), 0)::REAL AS actual_amount
+FROM transaction t
+WHERE t.deleted_at IS NULL
+  AND t.category_id IS NULL
+  AND t.transaction_date >= sqlc.arg(period_start)::DATE
+  AND t.transaction_date < (sqlc.arg(period_end)::DATE + INTERVAL '1 day')
+  AND (
+      (sqlc.narg(household_id)::BIGINT IS NOT NULL AND t.household_id = sqlc.narg(household_id)::BIGINT)
+      OR
+      (sqlc.narg(user_id)::BIGINT IS NOT NULL AND t.author_id = sqlc.narg(user_id)::BIGINT)
+  );
+
+-- WRITES
+
+-- name: CreateHouseholdBudget :one
+INSERT INTO budget (household_id, user_id, period_start, period_end, source_budget_id)
+VALUES (
+    sqlc.arg(household_id)::BIGINT,
+    NULL,
+    sqlc.arg(period_start)::DATE,
+    sqlc.arg(period_end)::DATE,
+    sqlc.narg(source_budget_id)::BIGINT
+)
+RETURNING *;
+
+-- name: CreateUserBudget :one
+INSERT INTO budget (household_id, user_id, period_start, period_end, source_budget_id)
+VALUES (
+    NULL,
+    sqlc.arg(user_id)::BIGINT,
+    sqlc.arg(period_start)::DATE,
+    sqlc.arg(period_end)::DATE,
+    sqlc.narg(source_budget_id)::BIGINT
+)
+RETURNING *;
+
+-- name: CreateBudgetLine :one
+INSERT INTO budget_line (budget_id, name, allocation_amount, sort_order)
+VALUES (
+    sqlc.arg(budget_id)::BIGINT,
+    sqlc.arg(name)::VARCHAR,
+    sqlc.arg(allocation_amount)::NUMERIC,
+    sqlc.arg(sort_order)::INTEGER
+)
+RETURNING *;
+
+-- name: UpdateBudgetLine :one
+UPDATE budget_line
+SET
+    name = CASE
+        WHEN sqlc.arg(set_name)::bool THEN sqlc.arg(name)::VARCHAR
+        ELSE name
+    END,
+    allocation_amount = CASE
+        WHEN sqlc.arg(set_allocation_amount)::bool THEN sqlc.arg(allocation_amount)::NUMERIC
+        ELSE allocation_amount
+    END,
+    sort_order = CASE
+        WHEN sqlc.arg(set_sort_order)::bool THEN sqlc.arg(sort_order)::INTEGER
+        ELSE sort_order
+    END,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = sqlc.arg(id)::BIGINT
+RETURNING *;
+
+-- name: DeleteBudgetLine :exec
+DELETE FROM budget_line
+WHERE id = sqlc.arg(id)::BIGINT;
+
+-- name: DeleteBudgetLineCategories :exec
+DELETE FROM budget_line_category
+WHERE budget_line_id = sqlc.arg(budget_line_id)::BIGINT;
+
+-- name: CreateBudgetLineCategory :exec
+INSERT INTO budget_line_category (budget_id, budget_line_id, category_id)
+VALUES (
+    sqlc.arg(budget_id)::BIGINT,
+    sqlc.arg(budget_line_id)::BIGINT,
+    sqlc.arg(category_id)::BIGINT
+);
+
 -- ******************* transaction *******************
 -- READS
 

--- a/internal/database/query.sql
+++ b/internal/database/query.sql
@@ -123,8 +123,8 @@ SELECT
 FROM transaction t
 WHERE t.deleted_at IS NULL
   AND t.category_id IS NOT NULL
-  AND t.transaction_date >= sqlc.arg(period_start)::DATE
-  AND t.transaction_date < (sqlc.arg(period_end)::DATE + INTERVAL '1 day')
+  AND t.transaction_date >= (sqlc.arg(period_start)::DATE::TIMESTAMP AT TIME ZONE 'UTC')
+  AND t.transaction_date < ((sqlc.arg(period_end)::DATE + INTERVAL '1 day')::TIMESTAMP AT TIME ZONE 'UTC')
   AND (
       (sqlc.narg(household_id)::BIGINT IS NOT NULL AND t.household_id = sqlc.narg(household_id)::BIGINT)
       OR
@@ -138,8 +138,8 @@ SELECT COALESCE(SUM(t.amount), 0)::REAL AS actual_amount
 FROM transaction t
 WHERE t.deleted_at IS NULL
   AND t.category_id IS NULL
-  AND t.transaction_date >= sqlc.arg(period_start)::DATE
-  AND t.transaction_date < (sqlc.arg(period_end)::DATE + INTERVAL '1 day')
+  AND t.transaction_date >= (sqlc.arg(period_start)::DATE::TIMESTAMP AT TIME ZONE 'UTC')
+  AND t.transaction_date < ((sqlc.arg(period_end)::DATE + INTERVAL '1 day')::TIMESTAMP AT TIME ZONE 'UTC')
   AND (
       (sqlc.narg(household_id)::BIGINT IS NOT NULL AND t.household_id = sqlc.narg(household_id)::BIGINT)
       OR

--- a/internal/database/query.sql
+++ b/internal/database/query.sql
@@ -116,35 +116,48 @@ SELECT COALESCE(MAX(sort_order), 0)::INTEGER AS sort_order
 FROM budget_line
 WHERE budget_id = sqlc.arg(budget_id)::BIGINT;
 
--- name: ListBudgetTransactions :many
+-- name: ListBudgetReportLines :many
 SELECT
-    t.category_id::BIGINT AS category_id,
-    SUM(t.amount)::REAL AS actual_amount
-FROM transaction t
-WHERE t.deleted_at IS NULL
-  AND t.category_id IS NOT NULL
-  AND t.transaction_date >= (sqlc.arg(period_start)::DATE::TIMESTAMP AT TIME ZONE 'UTC')
-  AND t.transaction_date < ((sqlc.arg(period_end)::DATE + INTERVAL '1 day')::TIMESTAMP AT TIME ZONE 'UTC')
-  AND (
-      (sqlc.narg(household_id)::BIGINT IS NOT NULL AND t.household_id = sqlc.narg(household_id)::BIGINT)
-      OR
-      (sqlc.narg(user_id)::BIGINT IS NOT NULL AND t.author_id = sqlc.narg(user_id)::BIGINT)
-  )
-GROUP BY t.category_id
-ORDER BY t.category_id ASC;
+    bl.id,
+    bl.budget_id,
+    bl.name,
+    bl.allocation_amount,
+    ROUND(COALESCE(SUM(t.amount), 0)::NUMERIC, 2) AS actual_amount,
+    bl.sort_order
+FROM budget b
+JOIN budget_line bl ON bl.budget_id = b.id
+LEFT JOIN budget_line_category blc
+    ON blc.budget_id = b.id
+   AND blc.budget_line_id = bl.id
+LEFT JOIN transaction t
+    ON t.deleted_at IS NULL
+   AND t.category_id = blc.category_id
+   AND t.transaction_date >= (b.period_start::DATE::TIMESTAMP AT TIME ZONE 'UTC')
+   AND t.transaction_date < ((b.period_end::DATE + INTERVAL '1 day')::TIMESTAMP AT TIME ZONE 'UTC')
+   AND (
+       (b.household_id IS NOT NULL AND t.household_id = b.household_id)
+       OR
+       (b.user_id IS NOT NULL AND t.author_id = b.user_id)
+   )
+WHERE b.id = sqlc.arg(budget_id)::BIGINT
+GROUP BY bl.id, bl.budget_id, bl.name, bl.allocation_amount, bl.sort_order
+ORDER BY bl.sort_order ASC, bl.id ASC;
 
 -- name: SumUncategorizedBudgetTransactions :one
-SELECT COALESCE(SUM(t.amount), 0)::REAL AS actual_amount
-FROM transaction t
-WHERE t.deleted_at IS NULL
-  AND t.category_id IS NULL
-  AND t.transaction_date >= (sqlc.arg(period_start)::DATE::TIMESTAMP AT TIME ZONE 'UTC')
-  AND t.transaction_date < ((sqlc.arg(period_end)::DATE + INTERVAL '1 day')::TIMESTAMP AT TIME ZONE 'UTC')
-  AND (
-      (sqlc.narg(household_id)::BIGINT IS NOT NULL AND t.household_id = sqlc.narg(household_id)::BIGINT)
-      OR
-      (sqlc.narg(user_id)::BIGINT IS NOT NULL AND t.author_id = sqlc.narg(user_id)::BIGINT)
-  );
+SELECT ROUND(COALESCE(SUM(t.amount), 0)::NUMERIC, 2) AS actual_amount
+FROM budget b
+LEFT JOIN transaction t
+    ON t.deleted_at IS NULL
+   AND t.category_id IS NULL
+   AND t.transaction_date >= (b.period_start::DATE::TIMESTAMP AT TIME ZONE 'UTC')
+   AND t.transaction_date < ((b.period_end::DATE + INTERVAL '1 day')::TIMESTAMP AT TIME ZONE 'UTC')
+   AND (
+       (b.household_id IS NOT NULL AND t.household_id = b.household_id)
+       OR
+       (b.user_id IS NOT NULL AND t.author_id = b.user_id)
+   )
+WHERE b.id = sqlc.arg(budget_id)::BIGINT
+GROUP BY b.id;
 
 -- WRITES
 

--- a/internal/database/sqlc/models.go
+++ b/internal/database/sqlc/models.go
@@ -15,10 +15,29 @@ type Budget struct {
 	// Optional reference to a specific user for personal budgets.
 	UserID *int64 `json:"userId"`
 	// Optional reference to a household for shared group budgets.
-	HouseholdID *int64             `json:"householdId"`
-	Type        string             `json:"type"`
-	CreatedAt   pgtype.Timestamptz `json:"createdAt"`
-	UpdatedAt   pgtype.Timestamptz `json:"updatedAt"`
+	HouseholdID    *int64             `json:"householdId"`
+	CreatedAt      pgtype.Timestamptz `json:"createdAt"`
+	UpdatedAt      pgtype.Timestamptz `json:"updatedAt"`
+	PeriodStart    pgtype.Date        `json:"periodStart"`
+	PeriodEnd      pgtype.Date        `json:"periodEnd"`
+	SourceBudgetID *int64             `json:"sourceBudgetId"`
+}
+
+type BudgetLine struct {
+	ID               int64              `json:"id"`
+	BudgetID         int64              `json:"budgetId"`
+	Name             string             `json:"name"`
+	AllocationAmount pgtype.Numeric     `json:"allocationAmount"`
+	SortOrder        int32              `json:"sortOrder"`
+	CreatedAt        pgtype.Timestamptz `json:"createdAt"`
+	UpdatedAt        pgtype.Timestamptz `json:"updatedAt"`
+}
+
+type BudgetLineCategory struct {
+	BudgetID     int64              `json:"budgetId"`
+	BudgetLineID int64              `json:"budgetLineId"`
+	CategoryID   int64              `json:"categoryId"`
+	CreatedAt    pgtype.Timestamptz `json:"createdAt"`
 }
 
 type Category struct {

--- a/internal/database/sqlc/query.sql.go
+++ b/internal/database/sqlc/query.sql.go
@@ -1331,8 +1331,8 @@ SELECT
 FROM transaction t
 WHERE t.deleted_at IS NULL
   AND t.category_id IS NOT NULL
-  AND t.transaction_date >= $1::DATE
-  AND t.transaction_date < ($2::DATE + INTERVAL '1 day')
+  AND t.transaction_date >= ($1::DATE::TIMESTAMP AT TIME ZONE 'UTC')
+  AND t.transaction_date < (($2::DATE + INTERVAL '1 day')::TIMESTAMP AT TIME ZONE 'UTC')
   AND (
       ($3::BIGINT IS NOT NULL AND t.household_id = $3::BIGINT)
       OR
@@ -1800,8 +1800,8 @@ SELECT COALESCE(SUM(t.amount), 0)::REAL AS actual_amount
 FROM transaction t
 WHERE t.deleted_at IS NULL
   AND t.category_id IS NULL
-  AND t.transaction_date >= $1::DATE
-  AND t.transaction_date < ($2::DATE + INTERVAL '1 day')
+  AND t.transaction_date >= ($1::DATE::TIMESTAMP AT TIME ZONE 'UTC')
+  AND t.transaction_date < (($2::DATE + INTERVAL '1 day')::TIMESTAMP AT TIME ZONE 'UTC')
   AND (
       ($3::BIGINT IS NOT NULL AND t.household_id = $3::BIGINT)
       OR

--- a/internal/database/sqlc/query.sql.go
+++ b/internal/database/sqlc/query.sql.go
@@ -1324,51 +1324,60 @@ func (q *Queries) ListBudgetLines(ctx context.Context, budgetID int64) ([]Budget
 	return items, nil
 }
 
-const listBudgetTransactions = `-- name: ListBudgetTransactions :many
+const listBudgetReportLines = `-- name: ListBudgetReportLines :many
 SELECT
-    t.category_id::BIGINT AS category_id,
-    SUM(t.amount)::REAL AS actual_amount
-FROM transaction t
-WHERE t.deleted_at IS NULL
-  AND t.category_id IS NOT NULL
-  AND t.transaction_date >= ($1::DATE::TIMESTAMP AT TIME ZONE 'UTC')
-  AND t.transaction_date < (($2::DATE + INTERVAL '1 day')::TIMESTAMP AT TIME ZONE 'UTC')
-  AND (
-      ($3::BIGINT IS NOT NULL AND t.household_id = $3::BIGINT)
-      OR
-      ($4::BIGINT IS NOT NULL AND t.author_id = $4::BIGINT)
-  )
-GROUP BY t.category_id
-ORDER BY t.category_id ASC
+    bl.id,
+    bl.budget_id,
+    bl.name,
+    bl.allocation_amount,
+    ROUND(COALESCE(SUM(t.amount), 0)::NUMERIC, 2) AS actual_amount,
+    bl.sort_order
+FROM budget b
+JOIN budget_line bl ON bl.budget_id = b.id
+LEFT JOIN budget_line_category blc
+    ON blc.budget_id = b.id
+   AND blc.budget_line_id = bl.id
+LEFT JOIN transaction t
+    ON t.deleted_at IS NULL
+   AND t.category_id = blc.category_id
+   AND t.transaction_date >= (b.period_start::DATE::TIMESTAMP AT TIME ZONE 'UTC')
+   AND t.transaction_date < ((b.period_end::DATE + INTERVAL '1 day')::TIMESTAMP AT TIME ZONE 'UTC')
+   AND (
+       (b.household_id IS NOT NULL AND t.household_id = b.household_id)
+       OR
+       (b.user_id IS NOT NULL AND t.author_id = b.user_id)
+   )
+WHERE b.id = $1::BIGINT
+GROUP BY bl.id, bl.budget_id, bl.name, bl.allocation_amount, bl.sort_order
+ORDER BY bl.sort_order ASC, bl.id ASC
 `
 
-type ListBudgetTransactionsParams struct {
-	PeriodStart pgtype.Date `json:"periodStart"`
-	PeriodEnd   pgtype.Date `json:"periodEnd"`
-	HouseholdID *int64      `json:"householdId"`
-	UserID      *int64      `json:"userId"`
+type ListBudgetReportLinesRow struct {
+	ID               int64          `json:"id"`
+	BudgetID         int64          `json:"budgetId"`
+	Name             string         `json:"name"`
+	AllocationAmount pgtype.Numeric `json:"allocationAmount"`
+	ActualAmount     pgtype.Numeric `json:"actualAmount"`
+	SortOrder        int32          `json:"sortOrder"`
 }
 
-type ListBudgetTransactionsRow struct {
-	CategoryID   int64   `json:"categoryId"`
-	ActualAmount float32 `json:"actualAmount"`
-}
-
-func (q *Queries) ListBudgetTransactions(ctx context.Context, arg ListBudgetTransactionsParams) ([]ListBudgetTransactionsRow, error) {
-	rows, err := q.db.Query(ctx, listBudgetTransactions,
-		arg.PeriodStart,
-		arg.PeriodEnd,
-		arg.HouseholdID,
-		arg.UserID,
-	)
+func (q *Queries) ListBudgetReportLines(ctx context.Context, budgetID int64) ([]ListBudgetReportLinesRow, error) {
+	rows, err := q.db.Query(ctx, listBudgetReportLines, budgetID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []ListBudgetTransactionsRow
+	var items []ListBudgetReportLinesRow
 	for rows.Next() {
-		var i ListBudgetTransactionsRow
-		if err := rows.Scan(&i.CategoryID, &i.ActualAmount); err != nil {
+		var i ListBudgetReportLinesRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.BudgetID,
+			&i.Name,
+			&i.AllocationAmount,
+			&i.ActualAmount,
+			&i.SortOrder,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -1796,34 +1805,25 @@ func (q *Queries) SoftDeleteTransactionsById(ctx context.Context, arg SoftDelete
 }
 
 const sumUncategorizedBudgetTransactions = `-- name: SumUncategorizedBudgetTransactions :one
-SELECT COALESCE(SUM(t.amount), 0)::REAL AS actual_amount
-FROM transaction t
-WHERE t.deleted_at IS NULL
-  AND t.category_id IS NULL
-  AND t.transaction_date >= ($1::DATE::TIMESTAMP AT TIME ZONE 'UTC')
-  AND t.transaction_date < (($2::DATE + INTERVAL '1 day')::TIMESTAMP AT TIME ZONE 'UTC')
-  AND (
-      ($3::BIGINT IS NOT NULL AND t.household_id = $3::BIGINT)
-      OR
-      ($4::BIGINT IS NOT NULL AND t.author_id = $4::BIGINT)
-  )
+SELECT ROUND(COALESCE(SUM(t.amount), 0)::NUMERIC, 2) AS actual_amount
+FROM budget b
+LEFT JOIN transaction t
+    ON t.deleted_at IS NULL
+   AND t.category_id IS NULL
+   AND t.transaction_date >= (b.period_start::DATE::TIMESTAMP AT TIME ZONE 'UTC')
+   AND t.transaction_date < ((b.period_end::DATE + INTERVAL '1 day')::TIMESTAMP AT TIME ZONE 'UTC')
+   AND (
+       (b.household_id IS NOT NULL AND t.household_id = b.household_id)
+       OR
+       (b.user_id IS NOT NULL AND t.author_id = b.user_id)
+   )
+WHERE b.id = $1::BIGINT
+GROUP BY b.id
 `
 
-type SumUncategorizedBudgetTransactionsParams struct {
-	PeriodStart pgtype.Date `json:"periodStart"`
-	PeriodEnd   pgtype.Date `json:"periodEnd"`
-	HouseholdID *int64      `json:"householdId"`
-	UserID      *int64      `json:"userId"`
-}
-
-func (q *Queries) SumUncategorizedBudgetTransactions(ctx context.Context, arg SumUncategorizedBudgetTransactionsParams) (float32, error) {
-	row := q.db.QueryRow(ctx, sumUncategorizedBudgetTransactions,
-		arg.PeriodStart,
-		arg.PeriodEnd,
-		arg.HouseholdID,
-		arg.UserID,
-	)
-	var actual_amount float32
+func (q *Queries) SumUncategorizedBudgetTransactions(ctx context.Context, budgetID int64) (pgtype.Numeric, error) {
+	row := q.db.QueryRow(ctx, sumUncategorizedBudgetTransactions, budgetID)
+	var actual_amount pgtype.Numeric
 	err := row.Scan(&actual_amount)
 	return actual_amount, err
 }

--- a/internal/database/sqlc/query.sql.go
+++ b/internal/database/sqlc/query.sql.go
@@ -11,6 +11,64 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const createBudgetLine = `-- name: CreateBudgetLine :one
+INSERT INTO budget_line (budget_id, name, allocation_amount, sort_order)
+VALUES (
+    $1::BIGINT,
+    $2::VARCHAR,
+    $3::NUMERIC,
+    $4::INTEGER
+)
+RETURNING id, budget_id, name, allocation_amount, sort_order, created_at, updated_at
+`
+
+type CreateBudgetLineParams struct {
+	BudgetID         int64          `json:"budgetId"`
+	Name             string         `json:"name"`
+	AllocationAmount pgtype.Numeric `json:"allocationAmount"`
+	SortOrder        int32          `json:"sortOrder"`
+}
+
+func (q *Queries) CreateBudgetLine(ctx context.Context, arg CreateBudgetLineParams) (BudgetLine, error) {
+	row := q.db.QueryRow(ctx, createBudgetLine,
+		arg.BudgetID,
+		arg.Name,
+		arg.AllocationAmount,
+		arg.SortOrder,
+	)
+	var i BudgetLine
+	err := row.Scan(
+		&i.ID,
+		&i.BudgetID,
+		&i.Name,
+		&i.AllocationAmount,
+		&i.SortOrder,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const createBudgetLineCategory = `-- name: CreateBudgetLineCategory :exec
+INSERT INTO budget_line_category (budget_id, budget_line_id, category_id)
+VALUES (
+    $1::BIGINT,
+    $2::BIGINT,
+    $3::BIGINT
+)
+`
+
+type CreateBudgetLineCategoryParams struct {
+	BudgetID     int64 `json:"budgetId"`
+	BudgetLineID int64 `json:"budgetLineId"`
+	CategoryID   int64 `json:"categoryId"`
+}
+
+func (q *Queries) CreateBudgetLineCategory(ctx context.Context, arg CreateBudgetLineCategoryParams) error {
+	_, err := q.db.Exec(ctx, createBudgetLineCategory, arg.BudgetID, arg.BudgetLineID, arg.CategoryID)
+	return err
+}
+
 const createCategory = `-- name: CreateCategory :one
 
 INSERT INTO category (code, name, description)
@@ -37,6 +95,48 @@ func (q *Queries) CreateCategory(ctx context.Context, arg CreateCategoryParams) 
 		&i.IsActive,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const createHouseholdBudget = `-- name: CreateHouseholdBudget :one
+
+INSERT INTO budget (household_id, user_id, period_start, period_end, source_budget_id)
+VALUES (
+    $1::BIGINT,
+    NULL,
+    $2::DATE,
+    $3::DATE,
+    $4::BIGINT
+)
+RETURNING id, user_id, household_id, created_at, updated_at, period_start, period_end, source_budget_id
+`
+
+type CreateHouseholdBudgetParams struct {
+	HouseholdID    int64       `json:"householdId"`
+	PeriodStart    pgtype.Date `json:"periodStart"`
+	PeriodEnd      pgtype.Date `json:"periodEnd"`
+	SourceBudgetID *int64      `json:"sourceBudgetId"`
+}
+
+// WRITES
+func (q *Queries) CreateHouseholdBudget(ctx context.Context, arg CreateHouseholdBudgetParams) (Budget, error) {
+	row := q.db.QueryRow(ctx, createHouseholdBudget,
+		arg.HouseholdID,
+		arg.PeriodStart,
+		arg.PeriodEnd,
+		arg.SourceBudgetID,
+	)
+	var i Budget
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.HouseholdID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.PeriodStart,
+		&i.PeriodEnd,
+		&i.SourceBudgetID,
 	)
 	return i, err
 }
@@ -195,6 +295,46 @@ func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (User, e
 	return i, err
 }
 
+const createUserBudget = `-- name: CreateUserBudget :one
+INSERT INTO budget (household_id, user_id, period_start, period_end, source_budget_id)
+VALUES (
+    NULL,
+    $1::BIGINT,
+    $2::DATE,
+    $3::DATE,
+    $4::BIGINT
+)
+RETURNING id, user_id, household_id, created_at, updated_at, period_start, period_end, source_budget_id
+`
+
+type CreateUserBudgetParams struct {
+	UserID         int64       `json:"userId"`
+	PeriodStart    pgtype.Date `json:"periodStart"`
+	PeriodEnd      pgtype.Date `json:"periodEnd"`
+	SourceBudgetID *int64      `json:"sourceBudgetId"`
+}
+
+func (q *Queries) CreateUserBudget(ctx context.Context, arg CreateUserBudgetParams) (Budget, error) {
+	row := q.db.QueryRow(ctx, createUserBudget,
+		arg.UserID,
+		arg.PeriodStart,
+		arg.PeriodEnd,
+		arg.SourceBudgetID,
+	)
+	var i Budget
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.HouseholdID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.PeriodStart,
+		&i.PeriodEnd,
+		&i.SourceBudgetID,
+	)
+	return i, err
+}
+
 const deactivateCategory = `-- name: DeactivateCategory :one
 UPDATE category
 SET is_active = false,
@@ -216,6 +356,26 @@ func (q *Queries) DeactivateCategory(ctx context.Context, code string) (Category
 		&i.UpdatedAt,
 	)
 	return i, err
+}
+
+const deleteBudgetLine = `-- name: DeleteBudgetLine :exec
+DELETE FROM budget_line
+WHERE id = $1::BIGINT
+`
+
+func (q *Queries) DeleteBudgetLine(ctx context.Context, id int64) error {
+	_, err := q.db.Exec(ctx, deleteBudgetLine, id)
+	return err
+}
+
+const deleteBudgetLineCategories = `-- name: DeleteBudgetLineCategories :exec
+DELETE FROM budget_line_category
+WHERE budget_line_id = $1::BIGINT
+`
+
+func (q *Queries) DeleteBudgetLineCategories(ctx context.Context, budgetLineID int64) error {
+	_, err := q.db.Exec(ctx, deleteBudgetLineCategories, budgetLineID)
+	return err
 }
 
 const getActiveCategoryByCode = `-- name: GetActiveCategoryByCode :one
@@ -281,6 +441,47 @@ func (q *Queries) GetActiveSessionBySourceId(ctx context.Context, sourceID strin
 	return i, err
 }
 
+const getBudgetById = `-- name: GetBudgetById :one
+SELECT id, user_id, household_id, created_at, updated_at, period_start, period_end, source_budget_id FROM budget
+WHERE id = $1::BIGINT
+`
+
+func (q *Queries) GetBudgetById(ctx context.Context, id int64) (Budget, error) {
+	row := q.db.QueryRow(ctx, getBudgetById, id)
+	var i Budget
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.HouseholdID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.PeriodStart,
+		&i.PeriodEnd,
+		&i.SourceBudgetID,
+	)
+	return i, err
+}
+
+const getBudgetLineById = `-- name: GetBudgetLineById :one
+SELECT id, budget_id, name, allocation_amount, sort_order, created_at, updated_at FROM budget_line
+WHERE id = $1::BIGINT
+`
+
+func (q *Queries) GetBudgetLineById(ctx context.Context, id int64) (BudgetLine, error) {
+	row := q.db.QueryRow(ctx, getBudgetLineById, id)
+	var i BudgetLine
+	err := row.Scan(
+		&i.ID,
+		&i.BudgetID,
+		&i.Name,
+		&i.AllocationAmount,
+		&i.SortOrder,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const getCategoryByCode = `-- name: GetCategoryByCode :one
 SELECT id, code, name, description, is_active, created_at, updated_at FROM category
 WHERE code = $1
@@ -317,6 +518,39 @@ func (q *Queries) GetCategoryById(ctx context.Context, id int64) (Category, erro
 		&i.IsActive,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getHouseholdBudgetByPeriod = `-- name: GetHouseholdBudgetByPeriod :one
+
+SELECT id, user_id, household_id, created_at, updated_at, period_start, period_end, source_budget_id FROM budget
+WHERE household_id = $1::BIGINT
+  AND user_id IS NULL
+  AND period_start = $2::DATE
+  AND period_end = $3::DATE
+`
+
+type GetHouseholdBudgetByPeriodParams struct {
+	HouseholdID int64       `json:"householdId"`
+	PeriodStart pgtype.Date `json:"periodStart"`
+	PeriodEnd   pgtype.Date `json:"periodEnd"`
+}
+
+// ******************* budget *******************
+// READS
+func (q *Queries) GetHouseholdBudgetByPeriod(ctx context.Context, arg GetHouseholdBudgetByPeriodParams) (Budget, error) {
+	row := q.db.QueryRow(ctx, getHouseholdBudgetByPeriod, arg.HouseholdID, arg.PeriodStart, arg.PeriodEnd)
+	var i Budget
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.HouseholdID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.PeriodStart,
+		&i.PeriodEnd,
+		&i.SourceBudgetID,
 	)
 	return i, err
 }
@@ -417,6 +651,79 @@ func (q *Queries) GetIdByTransactionId(ctx context.Context, transactionID string
 	var id int64
 	err := row.Scan(&id)
 	return id, err
+}
+
+const getLatestPriorHouseholdBudget = `-- name: GetLatestPriorHouseholdBudget :one
+SELECT id, user_id, household_id, created_at, updated_at, period_start, period_end, source_budget_id FROM budget
+WHERE household_id = $1::BIGINT
+  AND user_id IS NULL
+  AND period_start < $2::DATE
+ORDER BY period_start DESC, id DESC
+LIMIT 1
+`
+
+type GetLatestPriorHouseholdBudgetParams struct {
+	HouseholdID int64       `json:"householdId"`
+	PeriodStart pgtype.Date `json:"periodStart"`
+}
+
+func (q *Queries) GetLatestPriorHouseholdBudget(ctx context.Context, arg GetLatestPriorHouseholdBudgetParams) (Budget, error) {
+	row := q.db.QueryRow(ctx, getLatestPriorHouseholdBudget, arg.HouseholdID, arg.PeriodStart)
+	var i Budget
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.HouseholdID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.PeriodStart,
+		&i.PeriodEnd,
+		&i.SourceBudgetID,
+	)
+	return i, err
+}
+
+const getLatestPriorUserBudget = `-- name: GetLatestPriorUserBudget :one
+SELECT id, user_id, household_id, created_at, updated_at, period_start, period_end, source_budget_id FROM budget
+WHERE user_id = $1::BIGINT
+  AND household_id IS NULL
+  AND period_start < $2::DATE
+ORDER BY period_start DESC, id DESC
+LIMIT 1
+`
+
+type GetLatestPriorUserBudgetParams struct {
+	UserID      int64       `json:"userId"`
+	PeriodStart pgtype.Date `json:"periodStart"`
+}
+
+func (q *Queries) GetLatestPriorUserBudget(ctx context.Context, arg GetLatestPriorUserBudgetParams) (Budget, error) {
+	row := q.db.QueryRow(ctx, getLatestPriorUserBudget, arg.UserID, arg.PeriodStart)
+	var i Budget
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.HouseholdID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.PeriodStart,
+		&i.PeriodEnd,
+		&i.SourceBudgetID,
+	)
+	return i, err
+}
+
+const getMaxBudgetLineSortOrder = `-- name: GetMaxBudgetLineSortOrder :one
+SELECT COALESCE(MAX(sort_order), 0)::INTEGER AS sort_order
+FROM budget_line
+WHERE budget_id = $1::BIGINT
+`
+
+func (q *Queries) GetMaxBudgetLineSortOrder(ctx context.Context, budgetID int64) (int32, error) {
+	row := q.db.QueryRow(ctx, getMaxBudgetLineSortOrder, budgetID)
+	var sort_order int32
+	err := row.Scan(&sort_order)
+	return sort_order, err
 }
 
 const getTableAndColumnMetadata = `-- name: GetTableAndColumnMetadata :many
@@ -743,6 +1050,36 @@ func (q *Queries) GetTransactionsByIdWithDetails(ctx context.Context, arg GetTra
 	return items, nil
 }
 
+const getUserBudgetByPeriod = `-- name: GetUserBudgetByPeriod :one
+SELECT id, user_id, household_id, created_at, updated_at, period_start, period_end, source_budget_id FROM budget
+WHERE user_id = $1::BIGINT
+  AND household_id IS NULL
+  AND period_start = $2::DATE
+  AND period_end = $3::DATE
+`
+
+type GetUserBudgetByPeriodParams struct {
+	UserID      int64       `json:"userId"`
+	PeriodStart pgtype.Date `json:"periodStart"`
+	PeriodEnd   pgtype.Date `json:"periodEnd"`
+}
+
+func (q *Queries) GetUserBudgetByPeriod(ctx context.Context, arg GetUserBudgetByPeriodParams) (Budget, error) {
+	row := q.db.QueryRow(ctx, getUserBudgetByPeriod, arg.UserID, arg.PeriodStart, arg.PeriodEnd)
+	var i Budget
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.HouseholdID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.PeriodStart,
+		&i.PeriodEnd,
+		&i.SourceBudgetID,
+	)
+	return i, err
+}
+
 const getUserByDiscordAndHouseholdId = `-- name: GetUserByDiscordAndHouseholdId :one
 SELECT u.id, u.discord_id, u.name, u.created_at, u.updated_at, u.telegram_id, u.phone_number, u.whatsapp_id FROM users u
 JOIN household_user hu on hu.user_id = u.id
@@ -904,6 +1241,142 @@ func (q *Queries) GetUserDetailsByDiscordId(ctx context.Context, discordID *stri
 		&i.Household.UpdatedAt,
 	)
 	return i, err
+}
+
+const listBudgetLineCategories = `-- name: ListBudgetLineCategories :many
+SELECT
+    blc.budget_id,
+    blc.budget_line_id,
+    blc.category_id,
+    c.code AS category_code,
+    c.name AS category_name
+FROM budget_line_category blc
+JOIN category c ON c.id = blc.category_id
+WHERE blc.budget_id = $1::BIGINT
+ORDER BY blc.budget_line_id ASC, c.name ASC, c.id ASC
+`
+
+type ListBudgetLineCategoriesRow struct {
+	BudgetID     int64  `json:"budgetId"`
+	BudgetLineID int64  `json:"budgetLineId"`
+	CategoryID   int64  `json:"categoryId"`
+	CategoryCode string `json:"categoryCode"`
+	CategoryName string `json:"categoryName"`
+}
+
+func (q *Queries) ListBudgetLineCategories(ctx context.Context, budgetID int64) ([]ListBudgetLineCategoriesRow, error) {
+	rows, err := q.db.Query(ctx, listBudgetLineCategories, budgetID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListBudgetLineCategoriesRow
+	for rows.Next() {
+		var i ListBudgetLineCategoriesRow
+		if err := rows.Scan(
+			&i.BudgetID,
+			&i.BudgetLineID,
+			&i.CategoryID,
+			&i.CategoryCode,
+			&i.CategoryName,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listBudgetLines = `-- name: ListBudgetLines :many
+SELECT id, budget_id, name, allocation_amount, sort_order, created_at, updated_at FROM budget_line
+WHERE budget_id = $1::BIGINT
+ORDER BY sort_order ASC, id ASC
+`
+
+func (q *Queries) ListBudgetLines(ctx context.Context, budgetID int64) ([]BudgetLine, error) {
+	rows, err := q.db.Query(ctx, listBudgetLines, budgetID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []BudgetLine
+	for rows.Next() {
+		var i BudgetLine
+		if err := rows.Scan(
+			&i.ID,
+			&i.BudgetID,
+			&i.Name,
+			&i.AllocationAmount,
+			&i.SortOrder,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listBudgetTransactions = `-- name: ListBudgetTransactions :many
+SELECT
+    t.category_id::BIGINT AS category_id,
+    SUM(t.amount)::REAL AS actual_amount
+FROM transaction t
+WHERE t.deleted_at IS NULL
+  AND t.category_id IS NOT NULL
+  AND t.transaction_date >= $1::DATE
+  AND t.transaction_date < ($2::DATE + INTERVAL '1 day')
+  AND (
+      ($3::BIGINT IS NOT NULL AND t.household_id = $3::BIGINT)
+      OR
+      ($4::BIGINT IS NOT NULL AND t.author_id = $4::BIGINT)
+  )
+GROUP BY t.category_id
+ORDER BY t.category_id ASC
+`
+
+type ListBudgetTransactionsParams struct {
+	PeriodStart pgtype.Date `json:"periodStart"`
+	PeriodEnd   pgtype.Date `json:"periodEnd"`
+	HouseholdID *int64      `json:"householdId"`
+	UserID      *int64      `json:"userId"`
+}
+
+type ListBudgetTransactionsRow struct {
+	CategoryID   int64   `json:"categoryId"`
+	ActualAmount float32 `json:"actualAmount"`
+}
+
+func (q *Queries) ListBudgetTransactions(ctx context.Context, arg ListBudgetTransactionsParams) ([]ListBudgetTransactionsRow, error) {
+	rows, err := q.db.Query(ctx, listBudgetTransactions,
+		arg.PeriodStart,
+		arg.PeriodEnd,
+		arg.HouseholdID,
+		arg.UserID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListBudgetTransactionsRow
+	for rows.Next() {
+		var i ListBudgetTransactionsRow
+		if err := rows.Scan(&i.CategoryID, &i.ActualAmount); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const listCategories = `-- name: ListCategories :many
@@ -1320,6 +1793,92 @@ func (q *Queries) SoftDeleteTransactionsById(ctx context.Context, arg SoftDelete
 		return nil, err
 	}
 	return items, nil
+}
+
+const sumUncategorizedBudgetTransactions = `-- name: SumUncategorizedBudgetTransactions :one
+SELECT COALESCE(SUM(t.amount), 0)::REAL AS actual_amount
+FROM transaction t
+WHERE t.deleted_at IS NULL
+  AND t.category_id IS NULL
+  AND t.transaction_date >= $1::DATE
+  AND t.transaction_date < ($2::DATE + INTERVAL '1 day')
+  AND (
+      ($3::BIGINT IS NOT NULL AND t.household_id = $3::BIGINT)
+      OR
+      ($4::BIGINT IS NOT NULL AND t.author_id = $4::BIGINT)
+  )
+`
+
+type SumUncategorizedBudgetTransactionsParams struct {
+	PeriodStart pgtype.Date `json:"periodStart"`
+	PeriodEnd   pgtype.Date `json:"periodEnd"`
+	HouseholdID *int64      `json:"householdId"`
+	UserID      *int64      `json:"userId"`
+}
+
+func (q *Queries) SumUncategorizedBudgetTransactions(ctx context.Context, arg SumUncategorizedBudgetTransactionsParams) (float32, error) {
+	row := q.db.QueryRow(ctx, sumUncategorizedBudgetTransactions,
+		arg.PeriodStart,
+		arg.PeriodEnd,
+		arg.HouseholdID,
+		arg.UserID,
+	)
+	var actual_amount float32
+	err := row.Scan(&actual_amount)
+	return actual_amount, err
+}
+
+const updateBudgetLine = `-- name: UpdateBudgetLine :one
+UPDATE budget_line
+SET
+    name = CASE
+        WHEN $1::bool THEN $2::VARCHAR
+        ELSE name
+    END,
+    allocation_amount = CASE
+        WHEN $3::bool THEN $4::NUMERIC
+        ELSE allocation_amount
+    END,
+    sort_order = CASE
+        WHEN $5::bool THEN $6::INTEGER
+        ELSE sort_order
+    END,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = $7::BIGINT
+RETURNING id, budget_id, name, allocation_amount, sort_order, created_at, updated_at
+`
+
+type UpdateBudgetLineParams struct {
+	SetName             bool           `json:"setName"`
+	Name                string         `json:"name"`
+	SetAllocationAmount bool           `json:"setAllocationAmount"`
+	AllocationAmount    pgtype.Numeric `json:"allocationAmount"`
+	SetSortOrder        bool           `json:"setSortOrder"`
+	SortOrder           int32          `json:"sortOrder"`
+	ID                  int64          `json:"id"`
+}
+
+func (q *Queries) UpdateBudgetLine(ctx context.Context, arg UpdateBudgetLineParams) (BudgetLine, error) {
+	row := q.db.QueryRow(ctx, updateBudgetLine,
+		arg.SetName,
+		arg.Name,
+		arg.SetAllocationAmount,
+		arg.AllocationAmount,
+		arg.SetSortOrder,
+		arg.SortOrder,
+		arg.ID,
+	)
+	var i BudgetLine
+	err := row.Scan(
+		&i.ID,
+		&i.BudgetID,
+		&i.Name,
+		&i.AllocationAmount,
+		&i.SortOrder,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
 }
 
 const updateCategory = `-- name: UpdateCategory :one


### PR DESCRIPTION
## Summary
- Add period-based household and personal budgets with normalized budget lines and category mappings.
- Add seamless monthly budget creation with transactional copy from the latest prior budget.
- Add line-level budget operations, derived budget reports, CLI commands, and CLI documentation.

## Details
- Budget actuals are derived from transaction categories instead of storing transaction-to-budget-line links.
- Budget reports net refunds naturally because refund transactions are negative amounts.
- Category mappings are unique per budget to prevent double-counting.

## Test Plan
- `env GOCACHE=/tmp/go-build go test ./...`
- `env GOCACHE=/tmp/go-build go build ./cmd/cli`
- stale budget category scan: `grep -RIn "budget_category_id\|BudgetCategoryID\|budget_category" internal db/migrations docs/superpowers/specs/2026-05-10-budget-design.md` (only historical migrations remain)